### PR TITLE
Insert X-Forwarded-Proto header = https

### DIFF
--- a/modules/app-gateway-module/main.tf
+++ b/modules/app-gateway-module/main.tf
@@ -1,3 +1,7 @@
+locals {
+  x_fwded_proto_ruleset = "x_fwded_proto"
+}
+
 resource "azurerm_application_gateway" "ag" {
   name                = "aks-fe-${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = local.vnet_rg
@@ -108,6 +112,21 @@ resource "azurerm_application_gateway" "ag" {
       http_listener_name         = request_routing_rule.value.name
       backend_address_pool_name  = request_routing_rule.value.name
       backend_http_settings_name = request_routing_rule.value.name
+      rewrite_rule_set_name      = local.x_fwded_proto_ruleset
+    }
+  }
+
+  rewrite_rule_set {
+    name = local.x_fwded_proto_ruleset
+
+    rewrite_rule {
+      name          = local.x_fwded_proto_ruleset
+      rule_sequence = 100
+
+      request_header_configuration {
+        header_name  = "X-Forwarded-Proto"
+        header_value = "https"
+      }
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
[AB#698](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/698)


### Change description ###
The app gateway is currently overwriting the X-Forwarded-Proto header sent by frontdoor, we need to re-insert it here so that app's that look at the request get the right protocol
https://azure.microsoft.com/en-gb/blog/rewrite-http-headers-with-azure-application-gateway/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
