### PR TITLE
Move to liveness for front door health probes

### DIFF
--- a/modules/azure-landing-zone/frontdoor.tf
+++ b/modules/azure-landing-zone/frontdoor.tf
@@ -89,7 +89,7 @@ resource "azurerm_frontdoor" "main" {
     content {
       name                = "healthProbeSettings-${host.value["name"]}"
       interval_in_seconds = 30
-      path                = "/health"
+      path                = "/health/liveness"
       protocol            = "Http"
     }
   }


### PR DESCRIPTION
Currently the health checks are not cached and using /health would mean too many calls to dependant apps.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
