### PR TITLE
Increasing health probe interval for front door

### DIFF
--- a/modules/azure-landing-zone/frontdoor.tf
+++ b/modules/azure-landing-zone/frontdoor.tf
@@ -88,7 +88,7 @@ resource "azurerm_frontdoor" "main" {
     for_each = var.frontends
     content {
       name                = "healthProbeSettings-${host.value["name"]}"
-      interval_in_seconds = 30
+      interval_in_seconds = 120
       path                = "/health/liveness"
       protocol            = "Http"
     }


### PR DESCRIPTION
Note that since Front Door have many edge environments globally, health probe requests volume to your backends can be as high as more than one request per second depends on the health probe frequency configured.

https://docs.microsoft.com/en-us/azure/frontdoor/front-door-health-probes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
