### PR TITLE
Update test.tfvars

### DIFF
--- a/environments/test.tfvars
+++ b/environments/test.tfvars
@@ -153,6 +153,11 @@ frontends = [
         operator       = "Equals"
         selector       = "token"
       },
+      {
+        match_variable = "RequestHeaderName"
+        operator       = "Equals"
+        selector       = "cookie"
+      },
     ]
   }
 ]

--- a/environments/test.tfvars
+++ b/environments/test.tfvars
@@ -154,9 +154,9 @@ frontends = [
         selector       = "token"
       },
       {
-        match_variable = "RequestHeaderName"
+        match_variable = "RequestCookieNames"
         operator       = "Equals"
-        selector       = "cookie"
+        selector       = "Idam.Session"
       },
     ]
   }


### PR DESCRIPTION
Idam.Session cookie being blocked by WAF rules, thus causing randon 403 errors via idam-web-public

