### PR TITLE
Re-add print service to frontdoor

### DIFF
--- a/environments/ithc.tfvars
+++ b/environments/ithc.tfvars
@@ -200,6 +200,13 @@ frontends = [
     certificate_name = "wildcard-ithc-platform-hmcts-net"
   },
   {
+    name             = "return-case-doc-ccd"
+    mode             = "Detection"
+    custom_domain    = "return-case-doc-ccd.ithc.platform.hmcts.net"
+    backend_domain   = ["firewall-nonprodi-palo-ithc.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-ithc-platform-hmcts-net"
+  },
+  {
     name             = "xui-approve-org"
     mode             = "Detection"
     custom_domain    = "administer-orgs.ithc.platform.hmcts.net"

--- a/environments/prod.tfvars
+++ b/environments/prod.tfvars
@@ -230,4 +230,11 @@ frontends = [
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "ccd-platform-hmcts-net"
   },
+  {
+    name             = "return-case-doc-ccd"
+    mode             = "Detection"
+    custom_domain    = "return-case-doc.ccd.platform.hmcts.net"
+    backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
+    certificate_name = "ccd-platform-hmcts-net"
+  },
 ]

--- a/environments/stg.tfvars
+++ b/environments/stg.tfvars
@@ -254,6 +254,13 @@ frontends = [
     certificate_name = "wildcard-aat-platform-hmcts-net"
   },
   {
+    name             = "return-case-doc-ccd"
+    mode             = "Detection"
+    custom_domain    = "return-case-doc-ccd.aat.platform.hmcts.net"
+    backend_domain   = ["firewall-prod-int-palo-aat.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-aat-platform-hmcts-net"
+  },
+  {
     name             = "pcq"
     custom_domain    = "pcq.aat.platform.hmcts.net"
     backend_domain   = ["firewall-prod-int-palo-aat.uksouth.cloudapp.azure.com"]

--- a/environments/test.tfvars
+++ b/environments/test.tfvars
@@ -97,6 +97,13 @@ frontends = [
     certificate_name = "wildcard-perftest-platform-hmcts-net"
   },
   {
+    name             = "return-case-doc-ccd"
+    mode             = "Detection"
+    custom_domain    = "return-case-doc-ccd.perftest.platform.hmcts.net"
+    backend_domain   = ["firewall-nonprodi-palo-perftest.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-perftest-platform-hmcts-net"
+  },
+  {
     name             = "idam-web-public"
     custom_domain    = "idam-web-public.perftest.platform.hmcts.net"
     backend_domain   = ["firewall-nonprodi-palo-perftest.uksouth.cloudapp.azure.com"]


### PR DESCRIPTION
### Change description ###
It seems like this service is accessed on two different urls currently,

1. case-management-web: https://github.com/hmcts/ccd-case-management-web/blob/master/infrastructure/prod.tfvars#L4 (the .platform domain)
2. api-gateway-web: https://github.com/hmcts/ccd-api-gateway/blob/master/infrastructure/main.tf#L20 the .internal domain


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
