### PR TITLE
fix SSL error on apex request

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -177,6 +177,13 @@ frontends = [
     ]
   },
   {
+    name             = "sscs-cor-apex"
+    mode             = "Detection"
+    custom_domain    = "manage.appeal-benefit-decision.service.gov.uk"
+    backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
+    certificate_name = "manage-appeal-benefit-decision-service-gov-uk"
+  },
+  {
     name             = "xui-webapp"
     mode             = "Detection"
     custom_domain    = "manage-case.platform.hmcts.net"


### PR DESCRIPTION
when requesting manage.appeal-benefit-decision.service.gov.uk there is no valid SSL provided from frontdoor, this should resolve this.

### Service Now Problem Record ###
PRB5000271 


### Change description ###
Added suitable SSL termination point for apex record for sscs-cor


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
