### PR TITLE
SIDM-3821 - stg.tfvars: idam: add dtSa cookie

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -404,6 +404,11 @@ frontends = [
         operator       = "Equals"
         selector       = "Idam.Session"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtSa"
+      },
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
SIDM-3821


### Change description ###
dtSa cookie is used by DynaTrace and has been flagged on a few requests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
