### PR TITLE
Disable waf rule 942440

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -648,6 +648,20 @@ frontends = [
     custom_domain    = "www.ccd.platform.hmcts.net"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "ccd-platform-hmcts-net"
+    disabled_rules = {
+      SQLI = [
+        "942100",
+        "942110",
+        "942150",
+        "942200",
+        "942210",
+        "942230",
+        "942361",
+        "942380",
+        "942400",
+        "942440",
+      ]
+    }
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"
@@ -673,6 +687,7 @@ frontends = [
         "942361",
         "942380",
         "942400",
+        "942440",
       ]
       LFI = [
         "930100", // false positive on multi-part uploads

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -650,15 +650,6 @@ frontends = [
     certificate_name = "ccd-platform-hmcts-net"
     disabled_rules = {
       SQLI = [
-        "942100",
-        "942110",
-        "942150",
-        "942200",
-        "942210",
-        "942230",
-        "942361",
-        "942380",
-        "942400",
         "942440",
       ]
     }


### PR DESCRIPTION
### Change description ###

We would like to disable WAF rule "DefaultRuleSet-1.0-SQLI-942440" on gatewayccdprod and wwwccdprod as there is an ongoing incident caused by the rule blocking hundreds of requests every two minutes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
