### PR TITLE
disabled rule 932115 for probate

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -710,6 +710,11 @@ frontends = [
     custom_domain    = "www.apply-for-probate.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "apply-for-probate-service-gov-uk"
+    disabled_rules = {
+      RCE = [
+        "932115"
+      ]
+    }
     global_exclusions = [
       {
         match_variable = "RequestCookieNames"


### PR DESCRIPTION
### JIRA link (if applicable) ###

ServiceNow Change Request: CHG5001130

### Change description ###

Probate API calls are getting blocked by WAF due to false-positive detection with certain WAF rules.
The request payloads in such calls are coincidentally containing specific sequences of characters (like post codes in addresses) that resemble keywords/commands in some scripting languages, command sets, etc. WAF is then treating them as suspicious and blocking them.

The preferred solution is to design and implement smarter logic in the WAF rules. In the interest of time and subject to IA approval, we can resolve the issue by disabling the following rules identified by DevOps:
932115 - REQUEST-932-APPLICATION-ATTACK-RCE - Remote Command Execution: Windows Command Injection

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
