### PR TITLE
Add ia-home-office-mock-api to AAT

### DIFF
--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -34,6 +34,8 @@ gateways:
       - product: ia
         component: home-office-integration-api
       - product: ia
+        component: home-office-mock-api
+      - product: ia
         component: timed-event-service
       - product: ia
         component: case-payments-api


### PR DESCRIPTION
Run ia-home-office-mock-api in AAT environment
ia-home-office-integration-api needs a mock server, for testing purpose.

JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-3074
https://tools.hmcts.net/jira/browse/RIA-3071

Change description
ia-home-office-integration-api needs a mock server, for testing purpose. We have generated a server stub in ia-home-office-mock-api, which should be available in AAT
The server in Preview gets stale and is removed after some time.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```