### PR TITLE
PCQ WAF mode Switched to Prevention mode

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -919,10 +919,22 @@ frontends = [
   },
   {
     name             = "pcq"
-    mode             = "Detection"
+    mode             = "Prevention"
     custom_domain    = "equality-and-diversity.platform.hmcts.net"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "equality-and-diversity-platform-hmcts-net"
+    global_exclusions = [
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "connect.sid"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
+    ]
   },
   {
     name             = "jui-redirect"


### PR DESCRIPTION
### JIRA link (if applicable) ###
#PCQ-520


### Change description ###
The WAF mode for the PCQ (Equality and Diversity) is changed to "Prevention" mode in the production environment with a couple of exclusion rules. These rules have been agreed by SecOps. -Agnes Pasca and Andrew Borisevic.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
