### PR TITLE
chore(idam-nonprod): disable appgw cookie affinity

### DIFF
--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -133,6 +133,7 @@ gateways:
         ssl_enabled: true
       - product: idam
         component: web-admin
+        cookie_based_affinity: Enabled
         ssl_enabled: true
 
     # CMC

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -130,11 +130,9 @@ gateways:
     # SIDAM
       - product: idam
         component: api
-        cookie_based_affinity: Enabled
         ssl_enabled: true
       - product: idam
         component: web-admin
-        cookie_based_affinity: Enabled
         ssl_enabled: true
 
     # CMC

--- a/environments/ldata/backend_lb_config.yaml
+++ b/environments/ldata/backend_lb_config.yaml
@@ -28,11 +28,9 @@ gateways:
     # SIDAM
       - product: idam
         component: api-ethosldata
-        cookie_based_affinity: Enabled
         ssl_enabled: true
       - product: idam
         component: web-admin-ethosldata
-        cookie_based_affinity: Enabled
         ssl_enabled: true
 
     # Ethos

--- a/environments/ldata/backend_lb_config.yaml
+++ b/environments/ldata/backend_lb_config.yaml
@@ -31,6 +31,7 @@ gateways:
         ssl_enabled: true
       - product: idam
         component: web-admin-ethosldata
+        cookie_based_affinity: Enabled
         ssl_enabled: true
 
     # Ethos

--- a/environments/sbox/backend_lb_config.yaml
+++ b/environments/sbox/backend_lb_config.yaml
@@ -60,6 +60,7 @@ gateways:
         ssl_enabled: true
       - product: idam
         component: web-admin
+        cookie_based_affinity: Enabled
         ssl_enabled: true
 
       - product: idam
@@ -67,4 +68,5 @@ gateways:
         ssl_enabled: true
       - product: idam
         component: web-admin-sprod
+        cookie_based_affinity: Enabled
         ssl_enabled: true

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -206,19 +206,10 @@ gateways:
 # IDAM AAT
       - product: idam
         component: api
-        cookie_based_affinity: Enabled
         ssl_enabled: true
       - product: idam
         component: web-admin
         cookie_based_affinity: Enabled
-        ssl_enabled: true
-
-# IDAM AAT2
-      - product: idam
-        component: api-aat2
-        ssl_enabled: true
-      - product: idam
-        component: web-admin-aat2
         ssl_enabled: true
 
 # rse

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -216,11 +216,9 @@ gateways:
 # IDAM AAT2
       - product: idam
         component: api-aat2
-        cookie_based_affinity: Enabled
         ssl_enabled: true
       - product: idam
         component: web-admin-aat2
-        cookie_based_affinity: Enabled
         ssl_enabled: true
 
 # rse

--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -160,9 +160,7 @@ gateways:
     # SIDAM
       - product: idam
         component: api
-        cookie_based_affinity: Enabled
         ssl_enabled: true
       - product: idam
         component: web-admin
-        cookie_based_affinity: Enabled
         ssl_enabled: true

--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -163,4 +163,5 @@ gateways:
         ssl_enabled: true
       - product: idam
         component: web-admin
+        cookie_based_affinity: Enabled
         ssl_enabled: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-4430

### Change description ###

Disable app gateway session affinity cookie due to stateless sessions being implemented. Non-Prod environments only.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
