### PR TITLE
ExUI WAF rule param and cookie exclusions

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -502,6 +502,16 @@ frontends = [
         operator       = "Equals"
         selector       = "__auth__"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "xui-webapp"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "rf"
+      },
     ]
   },
   {
@@ -538,6 +548,11 @@ frontends = [
         operator       = "Equals"
         selector       = "__auth__"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "xui-manage-org"
+      },
     ]
   },
   {
@@ -573,6 +588,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "__auth__"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "xui-approve-org"
       },
     ]
   },


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2383
https://tools.hmcts.net/jira/browse/EUI-2382

### Change description ###
Ignore rf query param used by dynatrace when it's doing mysterious things to our app. This is only happening on manage cases.

Also ignore the session cookie now used by manage cases, and ignore the session cookies that will shortly be used by manage org and manage cases.
NOTE: register-org doesn't have it's own session cookie because it's not authenticated

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
