### PR TITLE
Disable FD caching for hmi-api

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -423,5 +423,6 @@ frontends = [
     custom_domain    = "hmi-apim.sandbox.platform.hmcts.net"
     backend_domain   = ["firewall-sbox-int-palo-hmiapimsbox.uksouth.cloudapp.azure.com"]
     certificate_name = "STAR-sandbox-platform-hmcts-net"
+    cache_enabled    = "false"
   }
 ]


### PR DESCRIPTION
**Before creating a pull request make sure that:**


Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
HMIS-440:
https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=1442&projectKey=HMIS&view=detail&selectedIssue=HMIS-440

### Change description ###
Disable caching on the sbox front door hmi-api routing rule as queries are producing false positives.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
