### PR TITLE
PAY-3849- PCI Pal antenna cookie exception

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -393,6 +393,11 @@ frontends = [
         operator       = "Equals"
         selector       = "DecodedUrl"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "__pcipal-info"
+      },
     ]
   },
   {


### PR DESCRIPTION
This is a valid cookie for pci pal antenna changes and hence we are adding this to the exception list