### PR TITLE
Changes for az login with service principal for local-exec

### DIFF
--- a/modules/shutter_page/enable_https.tf
+++ b/modules/shutter_page/enable_https.tf
@@ -23,7 +23,7 @@ ${templatefile("${path.module}/templates/customHttps.json", {
     subscription_id : data.azurerm_client_config.current.subscription_id,
     vault_name : var.certificate_key_vault_name
 })}'
-
+az login --service-principal --username $clientId --password $secret --tenant $tenantId
 
 az rest --method POST \
  --uri "https://management.azure.com/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${data.azurerm_resource_group.shutter.name}/providers/Microsoft.Cdn/profiles/${azurerm_cdn_profile.main["${each.value.product}"].name}/endpoints/${azurerm_cdn_endpoint.shutter_endpoint["${each.value.name}"].name}/customDomains/${replace("${each.value.custom_domain}", ".", "-")}/enableCustomHttps?api-version=2019-04-15" \

--- a/pipeline-templates/terraform.yaml
+++ b/pipeline-templates/terraform.yaml
@@ -8,6 +8,20 @@
         inputs:
           terraformVersion: ${{ parameters.terraformVersion }}
 
+      - task: AzureCLI@2
+        displayName: AzureServicePrincipalAuth
+        inputs:
+          azureSubscription: '${{ parameters.service_connection }}'
+          scriptType: bash
+          scriptLocation: inlineScript
+          addSpnToEnvironment: true
+          inlineScript: |
+            #!/bin/bash
+            set -e 
+            echo "##vso[task.setvariable variable=ServicePrincipalId;]$servicePrincipalId"
+            echo "##vso[task.setvariable variable=ServicePrincipalKey;]$servicePrincipalKey"
+            echo "##vso[task.setvariable variable=TenantId;]$tenantId"
+
       - task: TerraformCLI@0
         displayName: Init - ${{ parameters.environment }} - ${{ parameters.component }}
         inputs:
@@ -28,6 +42,10 @@
           commandOptions: '-out=${{ parameters.environment }}${{ parameters.component }}${{ parameters.build }}plan -var-file=$(System.DefaultWorkingDirectory)/environments/${{ parameters.environment }}/${{ parameters.environment }}.tfvars'
           workingDirectory: '$(System.DefaultWorkingDirectory)/components/${{ parameters.component }}'
           environmentServiceName: '${{ parameters.service_connection }}'
+        env:
+          tenantId : $(TenantId)
+          clientId : $(ServicePrincipalId)
+          secret : $(ServicePrincipalKey)
 
       - task: Bash@3
         condition: and(succeeded(), eq(variables.isMaster, true))
@@ -46,6 +64,10 @@
           workingDirectory: '$(System.DefaultWorkingDirectory)/components/${{ parameters.component }}'
           environmentServiceName: '${{ parameters.service_connection }}'
           commandOptions: '${{ parameters.environment }}${{ parameters.component }}${{ parameters.build }}plan'        
+        env:
+          tenantId : $(TenantId)
+          clientId : $(ServicePrincipalId)
+          secret : $(ServicePrincipalKey)
 
       - task: Bash@3
         displayName: "Remove local tfstate"


### PR DESCRIPTION
### Change description ###
Part of shutter module currently not working due to requiring az login in local-exec to run az cli (az rest in this instance)

Added AzCLI@2 task to output SPN creds to allow TerraformCLI@0 to use these.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
