### PR TITLE
PAY-3882- Front door WAF enable to prevention mode

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -424,7 +424,7 @@ frontends = [
   {
     name             = "fees-register"
     custom_domain    = "fees-register.perftest.platform.hmcts.net"
-    mode             = "Detection"
+    mode             = "Prevention"
     backend_domain   = ["firewall-nonprodi-palo-perftest.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-perftest-platform-hmcts-net"
     custom_rules = [


### PR DESCRIPTION
On Perftest front door WAF needs to be activated on prevention mode for fees register