### PR TITLE
Exclude "__auth__" cookie from inspection

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -862,6 +862,11 @@ frontends = [
         operator       = "Equals"
         selector       = "__auth__"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "XSRF-TOKEN"
+      },
     ]
   },
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -857,6 +857,11 @@ frontends = [
         operator       = "Equals"
         selector       = "accessToken"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "__auth__"
+      },
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-10871
https://tools.hmcts.net/jira/browse/RDO-10599

### Change description ###
Exclude "__auth__" cookie from inspection in calls to ccd api gateway.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
