### PR TITLE
Revert civil damages ccd components

### DIFF
--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -242,33 +242,18 @@ gateways:
      # Unspec
       - product: unspec
         component: service
-
       - product: civil-damages
         component: service-xui-staging
       - product: civil-damages
         component: service-camunda-staging
       - product: civil-damages
-        component: service-data-store-staging
-      - product: civil-damages
-        component: service-definition-store-staging
-
-      - product: civil-damages
         component: ccd-xui-staging
       - product: civil-damages
         component: ccd-camunda-staging
       - product: civil-damages
-        component: ccd-data-store-staging
-      - product: civil-damages
-        component: ccd-definition-store-staging
-
-      - product: civil-damages
         component: camunda-xui-staging
       - product: civil-damages
         component: camunda-camunda-staging
-      - product: civil-damages
-        component: camunda-data-store-staging
-      - product: civil-damages
-        component: camunda-definition-store-staging
 
       # Work Allocation
       - product: wa


### PR DESCRIPTION
Reverting the changes again to keep master pipeline green. Will be progressed on https://tools.hmcts.net/jira/browse/DTSPO-1354