### PR TITLE
Add private dns ithc

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -109,7 +109,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'Precheck'
+      dependsOn: 'sbox_cftapps_cluster_lb'
       files_list: 'components/cftapps_private_dns environments/ithc/ithc.tfvars environments/variables.tf'
       alwaysApply: false
 

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -103,6 +103,16 @@ parameters:
       files_list: 'components/cftapps_cluster_lb_backend modules/app-gateway-module-backend environments/ithc/backend_lb_config.yaml environments/ithc/ithc.tfvars environments/variables.tf'
       alwaysApply: false
 
+    - deployment: 'ithc_private_dns'
+      environment: 'ithc'
+      component: 'cftapps_private_dns'
+      service_connection: 'dcd-cftapps-ithc'
+      storage_account_rg: 'core-infra-ithc-rg'
+      storage_account_name: 'cftappsithc'
+      dependsOn: 'Precheck'
+      files_list: 'components/cftapps_private_dns environments/ithc/ithc.tfvars environments/variables.tf'
+      alwaysApply: false
+
     - deployment: 'ldata_cftapps_cluster_lb'
       environment: 'ldata'
       component: 'cftapps_cluster_lb'

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -5,6 +5,7 @@ gateways:
       host_name_suffix: service.core-compute-ithc.internal
       ssl_host_name_suffix: ithc.platform.hmcts.net
       certificate_name: wildcard-ithc-platform-hmcts-net
+      private_ip_address: 10.10.40.121
     app_configuration:
     # RPE
       - product: draft-store

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -8,6 +8,7 @@ certificate_key_vault_name = "cftapps-ithc"
 
 app_gw_private_ip_address = ["10.10.40.121"]
 data_subscription         = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+privatedns_subscription   = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 oms_env                   = "nonprod"
 
 shutter_storage = "TODO"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-1703

### Change description ###

- pipeline step added for ithc private dns.

- private_ip_address added to .yaml for private dns component.

- As part of this, dns_records & dns_zone need to be imported into TF prior to a successful apply (due to records/zone already present in Azure). Have added script for visibility for importing a_records at scale.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
