### PR TITLE
Production private_dns has some ttl not set to 300

### DIFF
--- a/components/cftapps_private_dns/main.tf
+++ b/components/cftapps_private_dns/main.tf
@@ -9,7 +9,7 @@ locals {
     for gateways, gateway in local.gateways : [
       for app in gateway.app_configuration : {
         name   = "${app.product}-${app.component}-${var.env}",
-        ttl    = lookup(app, "ttl", 300)
+        ttl    = lookup(app, "ttl", 300),
         record = ["${gateway.gateway_configuration.private_ip_address}"]
       }
     ]

--- a/components/cftapps_private_dns/main.tf
+++ b/components/cftapps_private_dns/main.tf
@@ -9,7 +9,7 @@ locals {
     for gateways, gateway in local.gateways : [
       for app in gateway.app_configuration : {
         name   = "${app.product}-${app.component}-${var.env}",
-        ttl    = 300,
+        ttl    = lookup(app, "ttl", 300)
         record = ["${gateway.gateway_configuration.private_ip_address}"]
       }
     ]


### PR DESCRIPTION
### Change description ###
Production private_dns has some ttl not set to 300
- Sets ttl to 300 if not included in product-component yaml file 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
