### PR TITLE
DTSPO-2599 Revert Sandbox change CDN SKU to Microsoft Standard

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -10,7 +10,7 @@ data_subscription         = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
 privatedns_subscription   = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
 oms_env                   = "sandbox"
 
-cdn_sku    = "Standard_Microsoft"
+cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-sbox-rg"
 
 cft_apps_ag_ip_address = "10.10.7.124"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2599


### Change description ###
Reverting [previous change](https://github.com/hmcts/azure-platform-terraform/pull/801) to Sandbox CDN SKU from Verizon to Microsoft Standard due to inability to use same custom domain across both Azure Front Door and Microsoft CDN (as it is hosted by Front Door).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
