### PR TITLE
Update app-gw IP to new cluster for private dns

### DIFF
--- a/environments/sbox/backend_lb_config.yaml
+++ b/environments/sbox/backend_lb_config.yaml
@@ -5,7 +5,7 @@ gateways:
       host_name_suffix: service.core-compute-sandbox.internal
       ssl_host_name_suffix: sandbox.platform.hmcts.net
       certificate_name: STAR-sandbox-platform-hmcts-net
-      private_ip_address: 10.10.7.122
+      private_ip_address: 10.2.13.122
     app_configuration:
     # RPE
       - product: draft-store


### PR DESCRIPTION
### Change description ###
Update app-gw IP to new cluster for private dns
- App GWs are built using environment/sbox_cft_akstf/sbox.tfvars (not to be considered in this PR)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
