### PR TITLE
SIDM-6092: Add 'nonce' to WAF exclusion list

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -306,6 +306,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1567,6 +1567,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -156,6 +156,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {
@@ -349,6 +354,11 @@ frontends = [
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "code"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
       },
     ]
   },

--- a/environments/sbox_cft_akstf/sbox_cft_akstf.tfvars
+++ b/environments/sbox_cft_akstf/sbox_cft_akstf.tfvars
@@ -152,6 +152,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {
@@ -345,6 +350,11 @@ frontends = [
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "code"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
       },
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -595,6 +595,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -367,6 +367,11 @@ frontends = [
         operator       = "Equals"
         selector       = "code"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "nonce"
+      },
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
* [INC5230074](https://mojcppprod.service-now.com/nav_to.do?uri=%2Fincident.do%3Fsys_id%3Dadbdd6161b513410d5ab8591f54bcb4d%26sysparm_record_target%3Dincident%26sysparm_record_row%3D1%26sysparm_record_rows%3D1%26sysparm_record_list%3Dactive%3Dtrue%5Eassignment_group%3Dec8c03f137ef7f44c21884f643990e24%5Eincident_state!%3D6%5Esys_class_name%3Dincident%5EORDERBYDESCsys_updated_on)
* https://tools.hmcts.net/jira/browse/SIDM-6092


### Change description ###
Add the standard OpenID Connect 'nonce' param to WAF exclusion lists for IDAM.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
