### PR TITLE
DTSPO-3773: Deploy Splunk Universal Forwarder on Private Nonprod Activegate

### DIFF
--- a/modules/dynatrace-activegate/variables.tf
+++ b/modules/dynatrace-activegate/variables.tf
@@ -86,3 +86,7 @@ variable "splunk_username_secret" {
 variable "splunk_password_secret" {
   default = "splunk-gui-admin-password"
 }
+
+variable "splunk_pass4symmkey_secret" {
+  default = "pass4SymmKey-forwarders-encryptedstring"
+}

--- a/modules/dynatrace-activegate/vm.tf
+++ b/modules/dynatrace-activegate/vm.tf
@@ -73,6 +73,12 @@ data "azurerm_key_vault_secret" "splunk_password" {
   key_vault_id = data.azurerm_key_vault.soc_vault.id
 }
 
+data "azurerm_key_vault_secret" "splunk_pass4symmkey" {
+  provider     = azurerm.soc
+  name         = var.splunk_pass4symmkey_secret
+  key_vault_id = data.azurerm_key_vault.soc_vault.id
+}
+
 
 
 resource "azurerm_linux_virtual_machine_scale_set" "main" {
@@ -157,5 +163,6 @@ module "splunk-uf" {
   virtual_machine_scale_set_id = azurerm_linux_virtual_machine_scale_set.main.id
   splunk_username              = data.azurerm_key_vault_secret.splunk_username.value
   splunk_password              = data.azurerm_key_vault_secret.splunk_password.value
+  splunk_pass4symmkey          = data.azurerm_key_vault_secret.splunk_pass4symmkey.value
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-3773


### Change description ###
Added keyvault secret read for splunk pass4SymmKey and passed value to external module call as required by the [updated external module](https://github.com/hmcts/terraform-module-splunk-universal-forwarder/pull/4).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
