### PR TITLE
SIDM-6433 Add email to web-public WAF exclusion list

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -231,6 +231,16 @@ frontends = [
         selector       = "password"
       },
       {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "username"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "password"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "redirect_uri"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -238,7 +238,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames",
         operator       = "StartsWith",
-        selector       = "password"
+        selector       = "email"
       },
       {
         match_variable = "QueryStringArgNames"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -527,6 +527,16 @@ frontends = [
         selector       = "password"
       },
       {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "username"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "password"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "redirect_uri"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -534,7 +534,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames",
         operator       = "StartsWith",
-        selector       = "password"
+        selector       = "email"
       },
       {
         match_variable = "QueryStringArgNames"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -300,7 +300,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames",
         operator       = "StartsWith",
-        selector       = "password"
+        selector       = "email"
       },
       {
         match_variable = "QueryStringArgNames"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -293,6 +293,16 @@ frontends = [
         selector       = "password"
       },
       {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "username"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames",
+        operator       = "StartsWith",
+        selector       = "password"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "redirect_uri"


### PR DESCRIPTION
[SIDM-6433](https://tools.hmcts.net/jira/browse/SIDM-6433)

As the form validation is deemed sufficient this avoid issues with certain character combinations being blocked even though it still is a valid email address

Update: included other non-prod environments