### PR TITLE
DTSPO-5165 - Add aat-01 back into clusters lb

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -20,7 +20,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.10.161.123"
-cft_apps_cluster_ips   = ["10.10.143.250"]
+cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### Change description ###
Follow up to [PR-926](https://github.com/hmcts/azure-platform-terraform/pull/926) Adding aat-01 back into cluster load balancing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
