### PR TITLE
SIDM 6667 idam whitelist dynatrace rf parameter

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1697,6 +1697,11 @@ frontends = [
         operator       = "Equals"
         selector       = "nonce"
       },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "rf"
+      }
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-6667

### Change description ###

Whitelist the "rf" parameter as required for Dynatrace monitoring. This will be merged after the change freeze as part of the idam 7.1 release (CHG5006589)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
