### PR TITLE
Remove os_type for Dynatrace Activegate splunk-UF

### DIFF
--- a/modules/dynatrace-activegate/vm.tf
+++ b/modules/dynatrace-activegate/vm.tf
@@ -164,6 +164,4 @@ module "splunk-uf" {
   splunk_username              = data.azurerm_key_vault_secret.splunk_username.value
   splunk_password              = data.azurerm_key_vault_secret.splunk_password.value
   splunk_pass4symmkey          = data.azurerm_key_vault_secret.splunk_pass4symmkey.value
-  os_type                      = "Linux"
-
 }


### PR DESCRIPTION
### Change description ###
Pipeline is failing, this change has been reverted in module:
https://github.com/hmcts/terraform-module-splunk-universal-forwarder/commit/d2e789a5801af4de76a5678c1896fa0e6bde2140#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
