### PR TITLE
DTSPO-5414 SBOX - Swapped cluster-00/01 in AGW load balancing

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -15,7 +15,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-sbox-rg"
 
 cft_apps_ag_ip_address = "10.2.13.124"
-cft_apps_cluster_ips   = ["10.2.11.250"]
+cft_apps_cluster_ips   = ["10.2.9.250"]
 
 hub = "sbox"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-5414


### Change description ###
Removed cft-sbox-01-aks from AGW load balancing prior to AKS version upgrade
Added cft-sbox-00-aks back to AGW load balancing following AKS version upgrade.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
