### PR TITLE
Upgrade the aks version to 1.21.7, routing traffic to only ithc-00, s…

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -19,7 +19,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.11.225.123"
-cft_apps_cluster_ips   = ["10.11.207.250", "10.11.223.250"]
+cft_apps_cluster_ips   = ["10.11.207.250"]
 
 frontends = [
   {


### PR DESCRIPTION
…o no traffic to ithc-01 during upgrade activity.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-6654

### Change description ###

Upgrading AKS version on ithc-01, removal of 10.11.223.250 required to rout traffic to 00 cluster only.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
