### PR TITLE
AKS upgrade switch traffic to be only be routed to ithc-01.

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -19,7 +19,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.11.225.123"
-cft_apps_cluster_ips   = ["10.11.207.250"]
+cft_apps_cluster_ips   = ["10.11.223.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-6654

### Change description ###

Switch traffic to route through one cluster ithc-01, then commence upgrade of ithc-00.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
