### PR TITLE
DTSPO-6658 - AAT - Add aat-00 back into AGW load balancer

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -20,7 +20,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.10.161.123"
-cft_apps_cluster_ips   = ["10.10.159.250"]
+cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6658


### Change description ###
AAT-00 has been rebuilt and adding back into AGW load balancer pool


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
