### PR TITLE
DTPSP-6658 - AAT - Add cluster-01 to AGW Traffic Routing

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -20,7 +20,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.10.161.123"
-cft_apps_cluster_ips   = ["10.10.143.250"]
+cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6658

### Change description ###
Add AAT-01 back to AGW load balancer pool following rebuild/upgrade completion.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
