### PR TITLE
DTSPO-7038 - AAT - Removed aat-01 from AGW pool for rebuild

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -20,7 +20,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.10.161.123"
-cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
+cft_apps_cluster_ips   = ["10.10.143.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7038


### Change description ###
Remove AAT-01 from AGW load balancer pool prior to rebuild/upgrade
Note: Jenkins currently using [AAT-00.](https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml#L46) (10.10.143.250)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
