### PR TITLE
DTSPO-3187 - Perftest AppGW 2nd Private IP Address Update

### DIFF
--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -289,7 +289,7 @@ gateways:
       host_name_suffix: service.core-compute-perftest.internal
       ssl_host_name_suffix: perftest.platform.hmcts.net
       certificate_name: wildcard-perftest-platform-hmcts-net
-      private_ip_address: 10.48.96.127
+      private_ip_address: 10.48.96.124
     app_configuration:
     # IDAM
       - product: idam

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -4,7 +4,7 @@ env                    = "perftest"
 subscription           = "test"
 certificate_name_check = false
 
-app_gw_private_ip_address = ["10.48.96.121","10.48.96.127"]
+app_gw_private_ip_address = ["10.48.96.121","10.48.96.124"]
 data_subscription         = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
 privatedns_subscription   = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 oms_env                   = "nonprod"


### PR DESCRIPTION
### Change description ###

Perfest has an updated 2nd IP from a previous master branch change but this cannot be used [as it is reserved](https://dev.azure.com/hmcts/CNP/_build/results?buildId=215370&view=logs&j=a7933cc5-c4a8-59bf-6fc5-a8f7ae673172&t=e2f986cf-b125-5f7d-afa2-56450cf5b9d2).
Changing to another IP address within the subnet range. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
