### PR TITLE
Revert "DTSPO-7038 - AAT - Remove aat-00 from AGW pool for rebuild"

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -20,7 +20,7 @@ shutter_apps = [
 ]
 
 cft_apps_ag_ip_address = "10.10.161.123"
-cft_apps_cluster_ips   = ["10.10.159.250"]
+cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
 
 frontends = [
   {


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#1027 following completion of AAT-00 rebuild.