### PR TITLE
Revert "DTSPO-3187 - SBOX - Switch Plum to Test Multi-AZ AGW"

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -365,7 +365,7 @@ frontends = [
     product          = "plum"
     name             = "plum"
     custom_domain    = "plum.sandbox.platform.hmcts.net"
-    backend_domain   = ["firewall-sbox-int-palo-sbox-test.uksouth.cloudapp.azure.com"]
+    backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     disabled_rules   = {}
   },


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#1042.  This is to move Plum back to old appgateway prior to switchover. 