### PR TITLE
Added exclusion for nfdiv civil domain as it looks like false positive

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -432,6 +432,11 @@ frontends = [
         operator       = "Equals"
         selector       = "applicant1UploadedFiles"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "applicant2UploadedFiles"
+      },
     ]
   },
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -427,6 +427,11 @@ frontends = [
         operator       = "Equals"
         selector       = "_csrf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "applicant1UploadedFiles"
+      },
     ]
   },
   {


### PR DESCRIPTION
Our requests are getting blocked after uploading files. It looks like false positive.
```
Rule name : DefaultRuleSet-1.0-SQLI-942260

Detects basic SQL authentication bypass attempts 2/3

[ { "matchVariableName": "PostParamValue:applicant1UploadedFiles", "matchVariableValue": "[{\"id\":\"223bd491-7986-4f46-a2e9-5e3723e75ef2\",\"name\":\"Screenshot 2022-03-29 at 16.49.47.png\"}]" } ]
```