### PR TITLE
Put civil partnership domain into detection to disable IP restriction

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -331,7 +331,7 @@ frontends = [
   {
     product          = "nfdiv"
     name             = "nfdiv-civil-partnership"
-    mode             = "Prevention"
+    mode             = "Detection"
     custom_domain    = "www.end-civil-partnership.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "end-civil-partnership-service-gov-uk"


### PR DESCRIPTION
Make end-civil-partnership.service.gov.uk public