### PR TITLE
SIDM-7073: Exclude post_logout_redirect_uri from WAF analysis

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -806,6 +806,11 @@ frontends = [
         operator       = "Equals"
         selector       = "nonce"
       },
+       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "post_logout_redirect_uri"
+      },
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7073


### Change description ###
Exclude post_logout_redirect_uri from WAF analysis in AAT. 
This parameter is used to redirect the user to a page after they have ended their session with the IdP. It is normal for the redirect URI to not match that of the IdP which triggers the FrontDoor WAF to block the request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
