### PR TITLE
SIDM-7073: Exclude post_logout_redirect_uri from WAF analysis

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1888,7 +1888,12 @@ frontends = [
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "rf"
-      }
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "post_logout_redirect_uri"
+      },
     ]
   },
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7073
[CHG5007713](https://mojcppprod.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3Dc91899aa1bbe4d506226da88b04bcb29%26sysparm_record_target%3Dchange_request%26sysparm_record_row%3D1%26sysparm_record_rows%3D69%26sysparm_record_list%3Drequested_by.departmentDYNAMIC08c5d81edb2a4700edfc7cbdae96193d%255Eassignment_group%253Dec8c03f137ef7f44c21884f643990e24%255EORDERBYDESCstart_date)

### Change description ###
Exclude post_logout_redirect_uri from WAF analysis in Prod. 
This parameter is used to redirect the user to a page after they have ended their session with the IdP. It is normal for the redirect URI to not match that of the IdP which triggers the FrontDoor WAF to block the request.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
