### PR TITLE
SIDM-7584: Exclude client_id from WAF analysis, when sent as a form param

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -130,6 +130,11 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
+        selector       = "client_id"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
         selector       = "code"
       },
       {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1692,6 +1692,11 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
+        selector       = "client_id"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
         selector       = "code"
       },
       {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1692,11 +1692,6 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
-        selector       = "client_id"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
         selector       = "code"
       },
       {

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -39,6 +39,11 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
+        selector       = "client_id"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
         selector       = "code"
       },
       {

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -614,6 +614,11 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
+        selector       = "client_id"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
         selector       = "code"
       },
       {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -191,6 +191,11 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
+        selector       = "client_id"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
         selector       = "code"
       },
       {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SIDM-7584


### Change description ###
WAF has already been configured to exclude "client_id" from its analyis when used as a query param - it also needs to be excluded when passed as a POST param.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
