### PR TITLE
PCQ - Add LFI exclusions for dynatrace false positives

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2003,6 +2003,12 @@ frontends = [
     custom_domain    = "equality-and-diversity.platform.hmcts.net"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "equality-and-diversity-platform-hmcts-net"
+    disabled_rules = {
+      LFI = [
+        "930100", // false positive on multi-part uploads
+        "930110", // false positive on multi-part uploads
+      ]
+    }
     global_exclusions = [
       {
         match_variable = "RequestCookieNames"


### PR DESCRIPTION
### Change description ###

LFI exclusions to prevents blocking of dynatrace RUM beacon post calls.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
