### PR TITLE
Fix issues with terraform 2.99 upgrade

### DIFF
--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "backendappgateway" {
-  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=terraform-v2.99-upgrade"
 
   yaml_path                          = "${path.cwd}/../../environments/${local.env}/backend_lb_config.yaml"
   env                                = local.dns_zone

--- a/components/cftapps_cluster_lb_backend/main.tf
+++ b/components/cftapps_cluster_lb_backend/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "app-gw" {
-  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=terraform-v2.99-upgrade"
 
   yaml_path                  = "${path.cwd}/../../environments/${local.env}/backend_lb_config.yaml"
   env                        = local.dns_zone


### PR DESCRIPTION
### Change description ###
Use branch for backend app gw which ensures compatibility with AzureRM provider versions 2.96.0 and above


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
