### PR TITLE
DTSPO-8837 - Azurerm v3 provider private dns

### DIFF
--- a/components/cftapps_private_dns/provider.tf
+++ b/components/cftapps_private_dns/provider.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.58.0"
+      version = "3.10.0"
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8837


### Change description ###
Use azurerm v3 provider for private dns
No infrastructure changes related to this component
null_resource.enable_custom_https_cmd["lau"] in prod shutter will be recreated going by latest plan

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
