### PR TITLE
DTSPO-8837 - Azurerm v3 provider frontend appgw

### DIFF
--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -13,7 +13,7 @@ module "ctags" {
 data "azurerm_subscription" "current" {}
 
 module "frontendappgateway" {
-  source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=terraform-azurerm-v3"
 
   env                                = var.env
   subscription                       = var.subscription

--- a/components/frontendappgateway/provider.tf
+++ b/components/frontendappgateway/provider.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.58.0"
+      version = "3.10.0"
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8837


### Change description ###
Use azurerm v3 provider for frontend app gw
Request_routing_rules, http_listeners, health_probes will be shuffled around due to the priority and provider updates but overall there should be no changes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
