### PR TITLE
DTSPO-9050 - Update dependsOn to sbox non-global

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -114,7 +114,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'ithc_private_dns'
       environment: 'ithc'
@@ -122,7 +122,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_private_dns'
 
     - deployment: 'ithc_apim'
       environment: 'ithc'
@@ -130,7 +130,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_apim'
 
     - deployment: 'demo_cftapps_cluster_lb_backend'
       environment: 'demo'
@@ -138,7 +138,7 @@ parameters:
       service_connection: 'dcd-cftapps-demo'
       storage_account_rg: 'core-infra-demo-rg'
       storage_account_name: 'cftappsdemo'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'demo_private_dns'
       environment: 'demo'
@@ -146,7 +146,7 @@ parameters:
       service_connection: 'dcd-cftapps-demo'
       storage_account_rg: 'core-infra-demo-rg'
       storage_account_name: 'cftappsdemo'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_private_dns'
 
     - deployment: 'demo_apim'
       environment: 'demo'
@@ -154,7 +154,7 @@ parameters:
       service_connection: 'dcd-cftapps-demo'
       storage_account_rg: 'core-infra-demo-rg'
       storage_account_name: 'cftappsdemo'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_apim'
 
     - deployment: 'test_frontendappgateway'
       environment: 'test'
@@ -170,7 +170,7 @@ parameters:
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'test_cftapps_cluster_lb'
       environment: 'test'
@@ -186,7 +186,7 @@ parameters:
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'test_cftapps_private_dns'
       environment: 'test'
@@ -202,7 +202,7 @@ parameters:
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_apim'
 
     - deployment: 'stg_cftapps_cluster_lb'
       environment: 'stg'
@@ -218,7 +218,7 @@ parameters:
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'stg_private_dns'
       environment: 'stg'
@@ -226,7 +226,7 @@ parameters:
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_private_dns'
 
     - deployment: 'stg_apim'
       environment: 'stg'
@@ -234,7 +234,7 @@ parameters:
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_apim'
 
     - deployment: 'prod_cftapps_cluster_lb'
       environment: 'prod'
@@ -250,7 +250,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_backendappgateway'
 
     - deployment: 'prod_shutter'
       environment: 'prod'
@@ -258,7 +258,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_shutter'
 
     - deployment: 'prod_private_dns'
       environment: 'prod'
@@ -266,7 +266,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_private_dns'
 
     - deployment: 'prod_apim'
       environment: 'prod'
@@ -274,7 +274,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_apim'
 
 stages:
   - stage: Precheck

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -194,7 +194,7 @@ parameters:
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_private_dns'
 
     - deployment: 'test_apim'
       environment: 'test'


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-9050

Change description
Update dependsOn conditions so that sbox must pass before other environments are targeted
Split into different related components. Previously all non-sbox environments had a dependency on sbox_frontendappgateway

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No
