### PR TITLE
Take out ithc-01 from cluster

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -21,7 +21,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.11.225.113"
-cft_apps_cluster_ips            = ["10.11.207.250", "10.11.223.250"]
+cft_apps_cluster_ips            = ["10.11.207.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

DTSPO-8027-Trafikv2-migration and aks upgrade


### Change description ###

Taking 10.11.223.250 out so ITHC-01 can be worked on adding new version of aks and traefikv2.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
