### PR TITLE
App Gateway Backend CI check to match pre-commit

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -18,6 +18,11 @@ resources:
     ref: refs/heads/master
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
+  - repository: pre-commit-hooks
+    type: github
+    ref: refs/heads/master
+    name: hmcts/pre-commit-hooks
+    endpoint: 'hmcts'
 
 variables:
   - name: timeoutInMinutes
@@ -284,12 +289,18 @@ stages:
           vmImage: ${{ variables.agentPool }}
         timeoutInMinutes: ${{ variables.timeoutInMinutes }}
         steps:
+          - checkout: pre-commit-hooks
           - template: steps/terraform-precheck.yaml@cnp-azuredevops-libraries
             parameters:
               keyvaultName: 'infra-vault-nonprod'
               keyvaultSecret: 'azure-devops-token'
               serviceConnection: 'azurerm-sandbox'
-
+          - task: Bash@3
+            displayName: "Application Gateway Backend Check"
+            inputs:
+              targetType: 'inline'
+              script: cd azure-platform-terraform && ../pre-commit-hooks/pre-commit-hooks/app_gateway_backend_check.sh
+              failOnStderr: true
 
   - ${{ each deployment in parameters.environment_components }}:
     - stage: ${{ deployment.deployment }}

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -13,9 +13,6 @@ gateways:
       private_ip_address: 10.11.225.111
     app_configuration:
     # RPE
-      - product: testing
-        component: service
-
       - product: draft-store
         component: service
       - product: cmc

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -13,7 +13,7 @@ gateways:
       private_ip_address: 10.11.225.111
     app_configuration:
     # RPE
-       - product: testing
+      - product: testing
         component: service
 
       - product: draft-store

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -13,6 +13,9 @@ gateways:
       private_ip_address: 10.11.225.111
     app_configuration:
     # RPE
+       - product: testing
+        component: service
+
       - product: draft-store
         component: service
       - product: cmc


### PR DESCRIPTION
### Change description ###
App Gateway Backend CI check to match pre-commit
- Went with inline rather than attempting to template 
- Requires a checkout of the additional repo, referencing `app_gateway_backend_check.sh@pre-commit-hooks` doesn't work

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
