### PR TITLE
Add initial platform pipeline tests

### DIFF
--- a/azure_pipeline-global.yaml
+++ b/azure_pipeline-global.yaml
@@ -54,10 +54,12 @@ parameters:
     default:
     - deployment: 'sbox_global'
       environment: 'sbox'
+      domain_prefix: 'sandbox'
       component: 'global'
       service_connection: 'dcd-cftapps-sbox'
       storage_account_rg: 'core-infra-sbox-rg'
       storage_account_name: 'cftappssbox'
+      pipeline_tests: true
       dependsOn: 'Precheck'
 
     - deployment: 'demo_global'
@@ -78,18 +80,22 @@ parameters:
 
     - deployment: 'ithc_global'
       environment: 'ithc'
+      domain_prefix: 'ithc'
       component: 'global'
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
+      pipeline_tests: true
       dependsOn: 'sbox_global'
 
     - deployment: 'perftest_global'
       environment: 'test'
+      domain_prefix: 'perftest'
       component: 'global'
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
+      pipeline_tests: true
       dependsOn: 'sbox_global'
 
     - deployment: 'aat_global'
@@ -138,3 +144,14 @@ stages:
                   serviceConnection: ${{ deployment.service_connection }}
                   terraformInitSubscription: ${{ variables.terraformInitSubscription }}
                   product: ${{ variables.product }}
+          - ${{ if eq(deployment.pipeline_tests, true) }}:
+            - job: PipelineTests
+              timeoutInMinutes: ${{ variables.timeoutInMinutes }}
+              dependsOn: TerraformPlanApply
+              steps:
+                - template: steps/pipeline_tests.yaml@cnp-azuredevops-libraries
+                  parameters:
+                    workingDirectory: $(Pipeline.Workspace)/s/scripts
+                    junit_output_dir: $(Pipeline.Workspace)/s/environments/${{ deployment.environment }}/junit
+                    environment: ${{ deployment.environment }}
+                    domain_prefix: ${{ deployment.domain_prefix }}

--- a/azure_pipeline-global.yaml
+++ b/azure_pipeline-global.yaml
@@ -149,7 +149,7 @@ stages:
               timeoutInMinutes: ${{ variables.timeoutInMinutes }}
               dependsOn: TerraformPlanApply
               steps:
-                - template: steps/pipeline_tests.yaml@cnp-azuredevops-libraries
+                - template: steps/pipeline_tests.yaml@cnp-azuredevops-libraries@DTSPO-9054/pipeline_tests_template
                   parameters:
                     workingDirectory: $(Pipeline.Workspace)/s/scripts
                     junit_output_dir: $(Pipeline.Workspace)/s/environments/${{ deployment.environment }}/junit

--- a/azure_pipeline-global.yaml
+++ b/azure_pipeline-global.yaml
@@ -24,7 +24,7 @@ resources:
   repositories:
     - repository: cnp-azuredevops-libraries
       type: github
-      ref: refs/heads/master
+      ref: refs/heads/DTSPO-9054/pipeline_tests_template
       name: hmcts/cnp-azuredevops-libraries
       endpoint: 'hmcts'
 variables:
@@ -149,7 +149,7 @@ stages:
               timeoutInMinutes: ${{ variables.timeoutInMinutes }}
               dependsOn: TerraformPlanApply
               steps:
-                - template: steps/pipeline_tests.yaml@cnp-azuredevops-libraries@DTSPO-9054/pipeline_tests_template
+                - template: steps/pipeline_tests.yaml@cnp-azuredevops-libraries
                   parameters:
                     workingDirectory: $(Pipeline.Workspace)/s/scripts
                     junit_output_dir: $(Pipeline.Workspace)/s/environments/${{ deployment.environment }}/junit

--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -132,7 +132,7 @@ gateways:
     # AAC (CDM)
       - product: aac
         component: manage-case-assignment
-        
+
     # CPO (CDM)
       - product: cpo
         component: case-payment-orders-api
@@ -305,7 +305,7 @@ gateways:
         component: bpm
         ssl_enabled: true
         cookie_based_affinity: Enabled
-        
+
 # Reference DATA
       - product: rd
         component: professional-api
@@ -335,7 +335,7 @@ gateways:
         component: location-ref-api-int
       - product: rd
         component: commondata-api
-        
+
     # HMC
       - product: hmc
         component: cft-hearing-service
@@ -343,6 +343,6 @@ gateways:
         component: hmi-inbound-adapter
       - product: hmc
         component: hmi-outbound-adapter
-        
+
       - product: sscs
         component: hearings-api

--- a/scripts/pipeline-tests.yaml
+++ b/scripts/pipeline-tests.yaml
@@ -1,0 +1,31 @@
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    global_domain: "{{ lookup('ansible.builtin.env', 'GLOBAL_DOMAIN_NAME') }}"
+
+  tasks:
+  - name: Perform tests
+    block:
+    - name: Test http redirect (plum)
+      ansible.builtin.uri:
+        url: "http://plum.{{ global_domain }}/"
+        follow_redirects: no
+        status_code: 301
+      register: http_response
+      failed_when: >
+        http_response.location !=  "https://plum." + global_domain + "/"
+
+    - name: Test http response (plum/health)
+      ansible.builtin.uri:
+        url: "https://plum.{{ global_domain }}/health"
+      register: http_response
+      failed_when: http_response.json.status != "UP"
+
+    - name: Test http response (plum/)
+      ansible.builtin.uri:
+        url: "https://plum.{{ global_domain }}/"
+        return_content: yes
+      register: http_response
+      failed_when: "'There are no recipes' not in http_response.content"
+    ignore_errors: yes

--- a/scripts/pipeline-tests.yaml
+++ b/scripts/pipeline-tests.yaml
@@ -14,11 +14,11 @@
         status_code: 301
       register: http_response
       failed_when: >
-        http_response.location !=  "https://plum404." + global_domain + "/"
+        http_response.location !=  "https://plum." + global_domain + "/"
 
     - name: Test http response (plum/health)
       ansible.builtin.uri:
-        url: "https://plum.{{ global_domain }}/health2"
+        url: "https://plum.{{ global_domain }}/health"
       register: http_response
       failed_when: http_response.json.status != "UP"
 
@@ -27,5 +27,5 @@
         url: "https://plum.{{ global_domain }}/"
         return_content: yes
       register: http_response
-      failed_when: "'There are no recipesOoPS' not in http_response.content"
+      failed_when: "'There are no recipes' not in http_response.content"
     ignore_errors: yes

--- a/scripts/pipeline-tests.yaml
+++ b/scripts/pipeline-tests.yaml
@@ -14,11 +14,11 @@
         status_code: 301
       register: http_response
       failed_when: >
-        http_response.location !=  "https://plum." + global_domain + "/"
+        http_response.location !=  "https://plum404." + global_domain + "/"
 
     - name: Test http response (plum/health)
       ansible.builtin.uri:
-        url: "https://plum.{{ global_domain }}/health"
+        url: "https://plum.{{ global_domain }}/health2"
       register: http_response
       failed_when: http_response.json.status != "UP"
 
@@ -27,5 +27,5 @@
         url: "https://plum.{{ global_domain }}/"
         return_content: yes
       register: http_response
-      failed_when: "'There are no recipes' not in http_response.content"
+      failed_when: "'There are no recipesOoPS' not in http_response.content"
     ignore_errors: yes


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-9054](https://tools.hmcts.net/jira/browse/DTSPO-9054)


### Change description ###

Add pipeline tests ADO to be used as part of other ADO pipelines (currently testing plum endpoints)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
