### PR TITLE
DTSPO-9055 - Add cert to plum aat

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -26,11 +26,11 @@ cft_apps_cluster_ips   = ["10.10.143.250", "10.10.159.250"]
 
 frontends = [
   {
-    name           = "plum"
-    custom_domain  = "plum.aat.platform.hmcts.net"
-    backend_domain = ["firewall-prod-int-palo-aat.uksouth.cloudapp.azure.com"]
-
-    disabled_rules = {}
+    name             = "plum"
+    custom_domain    = "plum.aat.platform.hmcts.net"
+    backend_domain   = ["firewall-prod-int-palo-aat.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-aat-platform-hmcts-net"
+    disabled_rules   = {}
   },
   {
     name           = "div-dn"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9055


### Change description ###
Wildcard cert missing for plum aat
Currently on microsoft managed as a result.
Will have to remove plum from frontdoor and re-add if this fails.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
