### PR TITLE
removing et-sya on fd on ithc due to error

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -1029,13 +1029,5 @@ frontends = [
     custom_domain    = "plum.ithc.platform.hmcts.net"
     backend_domain   = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-ithc-platform-hmcts-net"
-  },
-  {
-    product          = "et"
-    name             = "et-sya"
-    mode             = "Detection"
-    custom_domain    = "et-sya.ithc.platform.hmcts.net"
-    backend_domain   = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
-    certificate_name = "wildcard-ithc-platform-hmcts-net"
   }
 ]


### PR DESCRIPTION
### Change description ###
Spoke to Harpreet Jhita - causing error currently:
`│ Error: creating Front Door "hmcts-ithc" (Resource Group "lz-ithc-rg"): frontdoor.FrontDoorsClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="We couldn't find a DNS record for custom domain et-sya.ithc.platform.hmcts.net that points to Front Door hmcts-ithc.azurefd.net.To map a domain to this Front Door, create a CNAME record with your DNS provider for custom domain that points to Front Door."
`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
