### PR TITLE
RET-2055: updated the custom domain for the employment claims service

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2649,7 +2649,7 @@ frontends = [
     product          = "et"
     name             = "et-sya"
     mode             = "Detection"
-    custom_domain    = "et-sya.claim-employment-tribunals.service.gov.uk"
+    custom_domain    = "claim-employment-tribunals.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-claim-employment-tribunals-service-gov-uk"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2055

### Change description ###
updated the custom domain for the employment claims service to reflect changes in azure-public-dns

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
