### PR TITLE
RET-2055: Updated custom domain to employment tribunal claim service

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2654,7 +2654,7 @@ frontends = [
     product          = "et"
     name             = "et-sya"
     mode             = "Detection"
-    custom_domain    = "claim-employment-tribunals.service.gov.uk"
+    custom_domain    = "www.claim-employment-tribunals.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-prod.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-claim-employment-tribunals-service-gov-uk"
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RET-2055

### Change description ###
Updated custom domain to employment tribunal claim service (not live)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
