### PR TITLE
DTSPO-10835 - Add pipeline tests to prod global

### DIFF
--- a/azure_pipeline-global.yaml
+++ b/azure_pipeline-global.yaml
@@ -112,6 +112,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
+      pipeline_tests: true
       dependsOn: 'sbox_global'
 
 stages:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-10835


### Change description ###
Add pipeline tests to prod global stage
Was previously on hold whilst plum application was enabled on prod clusters

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
