### PR TITLE
DTSPO-10835 - AzureRM v2.99 - FrontDoor

### DIFF
--- a/components/global/main.tf
+++ b/components/global/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "landing_zone" {
-  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=DTSPO-10835/global-azurerm-2.99"
 
   common_tags                = module.ctags.common_tags
   env                        = var.env

--- a/components/global/provider.tf
+++ b/components/global/provider.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.58.0"
+      version = "2.99.0"
     }
   }
 }

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -556,7 +556,7 @@ frontends = [
     backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     disabled_rules   = {}
-    cache_enabled    = false
+    # cache_enabled    = false
   },
   {
     product          = "hmi"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -550,6 +550,14 @@ frontends = [
     disabled_rules   = {}
   },
   {
+    product          = "toffee"
+    name             = "toffee"
+    custom_domain    = "toffee.sandbox.platform.hmcts.net"
+    backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-sandbox-platform-hmcts-net"
+    disabled_rules   = {}
+  },
+  {
     product          = "hmi"
     name             = "hmi-apim"
     custom_domain    = "hmi-apim.sandbox.platform.hmcts.net"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -550,15 +550,6 @@ frontends = [
     disabled_rules   = {}
   },
   {
-    product          = "toffee"
-    name             = "toffee"
-    custom_domain    = "toffee.sandbox.platform.hmcts.net"
-    backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
-    certificate_name = "wildcard-sandbox-platform-hmcts-net"
-    disabled_rules   = {}
-    # cache_enabled    = false
-  },
-  {
     product          = "hmi"
     name             = "hmi-apim"
     custom_domain    = "hmi-apim.sandbox.platform.hmcts.net"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -556,6 +556,7 @@ frontends = [
     backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     disabled_rules   = {}
+    cache_enabled    = false
   },
   {
     product          = "hmi"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-10835


### Change description ###

- Upgrade azurerm on global (frontdoor) component to 2.99
- On global pipeline, any routing rules with `cache_enabled` set to `false` will have `cache_query_parameter_strip_directive` changed from `StripNone` to `StripAll`. 
- The value of `cache_query_parameter_strip_directive` cannot be `StripNone` when `cache_enabled` is `false` in this updated version of the provider.
- `cache_query_parameter_strip_directive` is not actually used when `cache_enabled` is `false` but this allows us to have one routing rule configuration to cover both scenarios.
- Apply has not yet been ran so this may fail but that is unknown at this point


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
