### PR TITLE
DTSPO-10835 - AzureRM 3.34 Frontend AppGW

### DIFF
--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -13,7 +13,7 @@ module "ctags" {
 data "azurerm_subscription" "current" {}
 
 module "frontendappgateway" {
-  source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=terraform-azurerm-v3"
 
   env                                = var.env
   subscription                       = var.subscription

--- a/components/frontendappgateway/provider.tf
+++ b/components/frontendappgateway/provider.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99.0"
+      version = "3.34.0"
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-10835

### Change description ###
- Upgrade azurerm provider on frontend appgw component to 3.34
- Branch applied against sbox already. No issues so far - plum still working.
- Health probes and routing rules get shuffled due to changes in the provider. Priority must be explicitly set in routing rules and status codes 200-399 are default for health probes.
- Branch is already in use in SDS

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
