### PR TITLE
Add second demo cluster, plum backend

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -402,3 +402,7 @@ gateways:
       # RPTS
       - product: rpts
         component: api
+
+      # CNP
+      - product: cnp
+        component: recipe-backend

--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -404,5 +404,5 @@ gateways:
         component: api
 
       # CNP
-      - product: cnp
+      - product: plum
         component: recipe-backend

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1,6 +1,6 @@
 env                    = "demo"
 subscription           = "demo"
-cft_apps_cluster_ips   = ["10.50.95.221"]
+cft_apps_cluster_ips   = ["10.50.79.221", "10.50.95.221"]
 certificate_name_check = false
 
 frontend_agw_private_ip_address = "10.50.97.122"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12612

This change:
- Updates backend clusters to include demo00 
- Adds plum-recipes as a backend for demo appgws


Looking to test behaviour for backends in demo in internal URLs and for DNS records existing 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
