### PR TITLE
add cpo-update-service to lb_config

### DIFF
--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -382,3 +382,7 @@ gateways:
         component: case-api
       - product: sptribs
         component: dss-backend
+    
+    # ccpay
+      - product: ccpay
+        component: cpo-update-service


### PR DESCRIPTION
Dynatrace monitor is failing for http://ccpay-cpo-update-service-aat.service.core-compute-aat.internal/health. As suggested by Dynatrace team, we are adding cpo-update-service to lb_config file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
