### PR TITLE
Add plum as front door entry

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -38,5 +38,12 @@ frontends = [
     custom_domain    = "plum-public.demo.platform.hmcts.net"
     backend_domain   = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
+  },
+  {
+    product          = "plum"
+    name             = "plum"
+    custom_domain    = "plum.demo.platform.hmcts.net"
+    backend_domain   = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-demo-platform-hmcts-net"
   }
 ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12612
This change:
- Adds plum as an entry to demo front door
- DNS pointing is handled in https://github.com/hmcts/azure-public-dns/pull/1098


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
