### PR TITLE
Remove RUM custom rule transformations

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -948,9 +948,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]
@@ -1019,9 +1016,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]
@@ -1471,9 +1465,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]
@@ -2208,9 +2199,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -737,9 +737,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]
@@ -803,9 +800,6 @@ frontends = [
             match_variable     = "RequestMethod"
             operator           = "Equal"
             negation_condition = false
-            transforms = [
-              "Uppercase"
-            ]
             match_values = [
               "POST"
             ]


### PR DESCRIPTION
This change:
- Removes a transform that Azure can no longer apply to custom rules of this type, which is causing pipeline stages to fail in this repo.
![image](https://user-images.githubusercontent.com/47995122/224750472-2ce42800-7abb-40b7-8fce-470e0f8036fe.png)

Transformation is not applied in Azure either currently, hence TF trying to create it on each run 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
