### PR TITLE
Add some leftover apps and -int apps

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -274,6 +274,8 @@ gateways:
         component: test-stubs-service
       - product: ccd
         component: ac-int-definition-store-api
+      - product: ccd
+        component: web-admin
     # FPRL
       - product: fprl
         component: cos
@@ -406,3 +408,11 @@ gateways:
       # CNP
       - product: plum
         component: recipe-backend
+
+      # ccd-int
+      - product: dm
+        component: store-ccd-int
+      - product: em
+        component: anno-ccd-int
+      - product: ccd
+        component: admin-ccd-int

--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -275,7 +275,7 @@ gateways:
       - product: ccd
         component: ac-int-definition-store-api
       - product: ccd
-        component: web-admin
+        component: admin-web
     # FPRL
       - product: fprl
         component: cos


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12614
This change:
- Adds some -int apps spotted when sifting through apps to migrate
- Adds ccd-admin-web


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
