### PR TITLE
Remove em app not currently in demo

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1761,13 +1761,6 @@ frontends = [
     www_redirect   = true
   },
   {
-    product        = "em"
-    name           = "em-icp"
-    mode           = "Detection"
-    custom_domain  = "em-icp.demo.platform.hmcts.net"
-    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
-  },
-  {
     product          = "fis-ds-update-web"
     name             = "fis-ds-update-web"
     custom_domain    = "dss-update-case.demo.platform.hmcts.net"


### PR DESCRIPTION
Was missed from DNS entries as it currently doesn't exist in demo causing build to fail https://dev.azure.com/hmcts/CNP/_build/results?buildId=355943&view=logs&jobId=954304bb-4c32-591b-a5c4-6cb202c035fc&j=954304bb-4c32-591b-a5c4-6cb202c035fc&t=27cdc44e-ab69-54e9-16e5-a0ff0e01f824


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
