### PR TITLE
Add hmi api demo

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -63,9 +63,9 @@ frontends = [
   },
   {
     name             = "hmi-apim"
-    custom_domain    = "hmi-apim.staging.platform.hmcts.net"
+    custom_domain    = "hmi-apim.demo.platform.hmcts.net"
     backend_domain   = ["firewall-prod-int-palo-hmiapimdemo.uksouth.cloudapp.azure.com"]
-    certificate_name = "wildcard-staging-platform-hmcts-net"
+    certificate_name = "wildcard-demo-platform-hmcts-net"
     cache_enabled    = "false"
   },
 ]

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -60,5 +60,12 @@ frontends = [
         selector       = "rf"
       },
     ]
-  }
+  },
+  {
+    name             = "hmi-apim"
+    custom_domain    = "hmi-apim.staging.platform.hmcts.net"
+    backend_domain   = ["firewall-prod-int-palo-hmiapimdemo.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-staging-platform-hmcts-net"
+    cache_enabled    = "false"
+  },
 ]

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -67,5 +67,5 @@ frontends = [
     backend_domain   = ["firewall-prod-int-palo-hmiapimdemo.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
     cache_enabled    = "false"
-  },
+  }
 ]


### PR DESCRIPTION
This change:

- Adds hmi-apim app to demo front door, backend is to hmi pip
- Dependent on https://github.com/hmcts/azure-public-dns/pull/1112


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
