### PR TITLE
Add remaining xui fe apps to demo

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1815,5 +1815,61 @@ frontends = [
     custom_domain  = "manage-case-hearings-int.demo.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
 
+  },
+  {
+    name           = "xui-register-org"
+    mode           = "Detection"
+    custom_domain  = "register-org.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-approve-org"
+    mode           = "Detection"
+    custom_domain  = "administer-orgs.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-manage-org"
+    mode           = "Detection"
+    custom_domain  = "manage-org.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-webapp-int1"
+    mode           = "Detection"
+    custom_domain  = "manage-case-int1.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-webapp-int2"
+    mode           = "Detection"
+    custom_domain  = "manage-case-int2.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-webapp"
+    mode           = "Detection"
+    custom_domain  = "manage-case.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-webapp-srt"
+    mode           = "Detection"
+    custom_domain  = "manage-case-srt.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
+  },
+  {
+    name           = "xui-webapp-wa-int"
+    mode           = "Detection"
+    custom_domain  = "manage-case-wa-int.demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+
   }
 ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12614

This change:
- Adds remaining FE apps to demo
- Requires:
  - DNS: https://github.com/hmcts/azure-public-dns/pull/1140
  - Flux: https://github.com/hmcts/cnp-flux-config/pull/21965/files



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
