### PR TITLE
Add Special Tribunals Citizen Frontend App

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2849,8 +2849,8 @@ frontends = [
     certificate_name = "claim-employment-tribunals-service-gov-uk"
   },
   {
-    product          = "st"
-    name             = "sptribs-frontend"
+    product          = "sptribs"
+    name             = "frontend"
     mode             = "Prevention"
     custom_domain    = "www.special-tribunals.service.gov.uk"
     ssl_mode         = "AzureKeyVault"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2853,6 +2853,7 @@ frontends = [
     name             = "sptribs-frontend"
     mode             = "Prevention"
     custom_domain    = "www.special-tribunals.service.gov.uk"
+    ssl_mode         = "AzureKeyVault"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]
     certificate_name = "special-tribunals-service-gov-uk"
   },

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2849,6 +2849,14 @@ frontends = [
     certificate_name = "claim-employment-tribunals-service-gov-uk"
   },
   {
+    product          = "st"
+    name             = "sptribs-case-api"
+    mode             = "Prevention"
+    custom_domain    = "www.special-tribunals.service.gov.uk"
+    backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]
+    certificate_name = "special-tribunals-service-gov-uk"
+  },
+  {
     name             = "dtsse-ardoq-adapter"
     product          = "dtsse"
     custom_domain    = "dtsse-ardoq-adapter.platform.hmcts.net"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2850,7 +2850,7 @@ frontends = [
   },
   {
     product          = "st"
-    name             = "sptribs-case-api"
+    name             = "sptribs-frontend"
     mode             = "Prevention"
     custom_domain    = "www.special-tribunals.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2850,7 +2850,7 @@ frontends = [
   },
   {
     product          = "sptribs"
-    name             = "frontend"
+    name             = "sptribs-frontend"
     mode             = "Prevention"
     custom_domain    = "www.special-tribunals.service.gov.uk"
     ssl_mode         = "AzureKeyVault"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ST-1365


### Change description ###
Add Special Tribunals Citizen Frontend App and custom domain to Prod Azure Front Door.

DNS zone is already created in this PR: https://github.com/hmcts/azure-public-dns/pull/1213.

Prod Apply check previously failed due to missing key vault certificate in "acmedcdcftappsprod". I don't have access to the vault to check or create a new cert.
I later found out from Louise in PlatOps there is a TLS cert self-service Function App running in Azure here: https://acmedcdcftappsprod.azurewebsites.net/.
This app let me create my TLS cert against my new DNS zone, and after re-running failed PR checks they are now passing.

Please create a new TLS cert as part of this PR review.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
