### PR TITLE
SIDM-8732: Add new cookie name for idam user dashboard

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2578,6 +2578,11 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-8732

### Change description ###

We're intending to introduce a new OIDC library for idam user dashboard but unfortunately, it necessitates changing the value of the session cookie from `idam-user-dashboard-session` to `idam_user_dashboard_session`. The plan is to allow both variants in the firewall, for now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
