### PR TITLE
SIDM-8736: Add auth_verification cookie to user dashboard

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1320,6 +1320,16 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -863,6 +863,16 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2583,6 +2583,11 @@ frontends = [
         selector       = "idam_user_dashboard_session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -457,6 +457,16 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -1467,6 +1467,16 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1066,6 +1066,16 @@ frontends = [
         selector       = "idam-user-dashboard-session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "idam_user_dashboard_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "auth_verification"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "jwt"


### PR DESCRIPTION
### JIRA link (if applicable) ###

[SIDM-8736](https://tools.hmcts.net/jira/browse/SIDM-8736)

### Change description ###

User dashboard needs another cookie exclusion from the firewall: `auth_verification`. Also added the updated user dashboard cookie name to other envs besides prod.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
