### PR TITLE
ITHC: Remove ithc01 internal LB to allow for AKS patch 1.26

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -21,7 +21,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.11.225.113"
-cft_apps_cluster_ips            = ["10.11.207.250", "10.11.223.250"]
+cft_apps_cluster_ips            = ["10.11.207.250"]
 
 frontends = [
   {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12901


### Change description ###

- Remove ithc01 internal LB to allow for AKS patch 1.26


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
