### PR TITLE
Revert "ITHC: Remove ithc00 for AKS patching to GA version 1.26"

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -21,7 +21,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.11.225.113"
-cft_apps_cluster_ips            = ["10.11.223.250"]
+cft_apps_cluster_ips            = ["10.11.207.250", "10.11.223.250"]
 
 frontends = [
   {


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#1639