### PR TITLE
Revert "Remove demo01 cluster for aks upgrades"

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1,6 +1,6 @@
 env                    = "demo"
 subscription           = "demo"
-cft_apps_cluster_ips   = ["10.50.79.221"]
+cft_apps_cluster_ips   = ["10.50.79.221", "10.50.95.221"]
 certificate_name_check = false
 
 frontend_agw_private_ip_address = "10.50.97.122"


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#1649 -- add 01 back into application gateway post-upgrade

Upgrade added as code https://github.com/hmcts/aks-cft-deploy/pull/495#event-9945959019