### PR TITLE
LAU-707: Add exclusions to align LAU AAT with Prod and unblock static assets

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -787,6 +787,28 @@ frontends = [
     mode           = "Detection"
     custom_domain  = "lau.aat.platform.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
+    global_exclusions = [
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "connect.sid"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "lau-cookie-preferences"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "lau-session"
+      },
+    ]
   },
   {
     name           = "judicial-payments"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-707

### Change description ###

Adding exclusions to Azure FD to unblock static assets. This will bring AAT in alignment with Production exclusions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
