### PR TITLE
Add DT cookies and params to cui-ra's exclusion list for AAT

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -1767,6 +1767,43 @@ frontends = [
     product        = "cui"
     name           = "cui-ra"
     custom_domain  = "cui-ra.aat.platform.hmcts.net"
-    backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
+    backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"],
+    global_exclusions = [
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtLatC"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtPC"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "rxVisitor"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "rxvt"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "rf"
+      },
+    ]
   },
 ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Dynatrace default cookies and params should be excluded from WAF analysis.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
