### PR TITLE
Update App Gateway module source branch name

### DIFF
--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -27,7 +27,7 @@ module "app-gw" {
     azurerm.kv  = azurerm.kv
   }
 
-  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=multiple-ssl-profile-general-rewrite-rule-set"
+  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=main"
   yaml_path                                    = "${path.cwd}/../../environments/${local.env}/apim_appgw_config.yaml"
   env                                          = local.dns_zone
   location                                     = var.location


### PR DESCRIPTION
### Jira link (if applicable)
SDT-115 (https://tools.hmcts.net/jira/browse/SDT-115)


### Change description ###
Changed terraform-module-apim-application-gateway source branch name used in Application Gateway module back to main.  This follows changes made to terraform-module-apim-application-gateway to allow different certificates to be used and the ability to specify rewrite rules in the configuration file.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
