### PR TITLE
post CFT  frontdoor migration clean up

### DIFF
--- a/components/global/main.tf
+++ b/components/global/main.tf
@@ -4,31 +4,11 @@ locals {
   key_vault_name = "acme${replace(lower(data.azurerm_subscription.current.display_name), "-", "")}"
 }
 
-module "landing_zone" {
-  count  = var.upgrade_frontdoor ? 0 : 1
-  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=master"
-
-  common_tags                = module.ctags.common_tags
-  env                        = var.env
-  project                    = var.project
-  location                   = var.location
-  frontends                  = var.frontends
-  ssl_mode                   = var.ssl_mode
-  resource_group             = data.azurerm_resource_group.main.name
-  subscription_id            = data.azurerm_subscription.current.subscription_id
-  certificate_key_vault_name = local.key_vault_name
-  oms_env                    = var.oms_env
-  certificate_name_check     = var.certificate_name_check
-  key_vault_resource_group   = data.azurerm_resource_group.key_vault.name
-  log_analytics_workspace_id = module.log_analytics_workspace.workspace_id
-  add_access_policy          = var.add_access_policy
-
-  diagnostics_storage_account_id    = azurerm_storage_account.diagnostics.id
-  send_access_logs_to_log_analytics = false
+moved {
+  from = module.premium_front_door[0]
+  to   = module.premium_front_door
 }
-
 module "premium_front_door" {
-  count  = var.upgrade_frontdoor ? 1 : 0
   source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=DTSPO-13992-test-new-version-of-frontdoor"
 
   common_tags                = module.ctags.common_tags

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -2170,4 +2170,3 @@ frontends = [
   }
 ]
 
-upgrade_frontdoor = true

--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -23,4 +23,3 @@ frontends = [
   }
 ]
 
-upgrade_frontdoor = true

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -1406,4 +1406,3 @@ frontends = [
   }
 ]
 
-upgrade_frontdoor = true

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -27,8 +27,8 @@ frontend_agw_max_capacity       = 15
 hub           = "prod"
 apim_sku_name = "Premium"
 
-publisher_email   = "DTSPlatformOps@HMCTS.NET"
-upgrade_frontdoor = true
+publisher_email = "DTSPlatformOps@HMCTS.NET"
+
 frontends = [
   {
     name             = "plum"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -22,9 +22,9 @@ cft_apps_cluster_ips            = ["10.2.11.250", "10.2.9.250"]
 
 apim_appgw_backend_pool_fqdns = ["firewall-sbox-int-palo-cftapimgmt.uksouth.cloudapp.azure.com"]
 
-hub               = "sbox"
-autoShutdown      = true
-upgrade_frontdoor = true
+hub          = "sbox"
+autoShutdown = true
+
 frontends = [
   {
     product          = "idam"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -24,8 +24,8 @@ shutter_apps = [
 frontend_agw_private_ip_address = "10.10.161.102"
 cft_apps_cluster_ips            = ["10.10.143.250", "10.10.159.250"]
 
-publisher_email   = "DTSPlatformOps@HMCTS.NET"
-upgrade_frontdoor = true
+publisher_email = "DTSPlatformOps@HMCTS.NET"
+
 frontends = [
   {
     name           = "plum"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1432,4 +1432,3 @@ frontends = [
     ]
   }
 ]
-upgrade_frontdoor = true

--- a/environments/variables.tf
+++ b/environments/variables.tf
@@ -175,7 +175,3 @@ variable "autoShutdown" {
 variable "apim_appgw_max_capacity" {
   default = 2
 }
-variable "upgrade_frontdoor" {
-  type    = bool
-  default = false
-}


### PR DESCRIPTION

### Change description ###
We do not need this upgrade_frontdoor field any more as all the frontdoors are now migrated to premium, we have to change the brach to master as well after merging the DTSPO-13992-test-new-version-of-frontdoor to master on the module.



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
