### PR TITLE
tt-pet QueryStringArgNames contains PostParamName

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3414,7 +3414,7 @@ frontends = [
       },
       {
         match_variable = "QueryStringArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "PostParamName"
       }
     ]


### PR DESCRIPTION
### Change description ###

* WAF exclusion for tt-pet QueryStringArgNames contains PostParamName instead of equals

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
