### PR TITLE
Configure App Gateway to set backend host name

### DIFF
--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -27,7 +27,7 @@ module "app-gw" {
     azurerm.kv  = azurerm.kv
   }
 
-  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=main"
+  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=backend-http-settings-host-name"
   yaml_path                                    = "${path.cwd}/../../environments/${local.env}/apim_appgw_config.yaml"
   env                                          = local.dns_zone
   location                                     = var.location

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -7,8 +7,8 @@ gateways:
     ssl_certificates:
       - certificate_name: wildcard-platform-hmcts-net
     app_configuration:
-      - product: cft-mtls
-        component: api-mgmt-appgw
+      - product: civil
+        component: sdt-commissioning
         ssl_enabled: true
         use_public_ip: true
         health_path_override: "/status-0123456789abcdef"
@@ -18,6 +18,44 @@ gateways:
         ssl_certificate_name: wildcard-platform-hmcts-net
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
+        listener_host_name_prefix: commissioning.sdt
+        listener_host_name_suffix: justice.gov.uk
+        listener_ssl_host_name_suffix: justice.gov.uk
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.platform.hmcts.net
+        add_rewrite_rule: true
+        rewrite_rules:
+          - name: "SdtAddCustomHeadersRule"
+            sequence: "100"
+            request_headers:
+              - header_name: "CLIENT-IP-AGW"
+                header_value: "{var_client_ip}"
+              - header_name: "X-ARR-ClientCertSub-AGW"
+                header_value: "{var_client_certificate_subject}"
+              - header_name: "URI-PATH-AGW"
+                header_value: "{var_uri_path}"
+          - name: "SdtUrlRewriteRule"
+            sequence: "200"
+            conditions:
+              - variable: "var_uri_path"
+                pattern: ".*/producers(?>-comx)?/service/sdtapi"
+            url:
+              components: "path_only"
+              path: "/sdt-gateway"
+      - product: civil
+        component: sdt
+        ssl_enabled: true
+        use_public_ip: true
+        health_path_override: "/status-0123456789abcdef"
+        add_ssl_profile: true
+        verify_client_cert_issuer_dn: true
+        rootca_certificate_name: civil_sdt_root_ca
+        ssl_certificate_name: wildcard-platform-hmcts-net
+        host_name_suffix: platform.hmcts.net
+        ssl_host_name_suffix: platform.hmcts.net
+        listener_host_name_prefix: sdt
+        listener_host_name_suffix: justice.gov.uk
+        listener_ssl_host_name_suffix: justice.gov.uk
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.platform.hmcts.net
         add_rewrite_rule: true
         rewrite_rules:
           - name: "SdtAddCustomHeadersRule"

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -5,7 +5,8 @@ gateways:
       exclude_env_in_app_name: true
       private_ip_address: 10.11.8.196
     ssl_certificates:
-      - certificate_name: wildcard-platform-hmcts-net
+      - certificate_name: civil-sdt-commissioning-prod
+      - certificate_name: civil-sdt-prod
     app_configuration:
       - product: civil
         component: sdt-commissioning
@@ -15,7 +16,7 @@ gateways:
         add_ssl_profile: true
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
-        ssl_certificate_name: wildcard-platform-hmcts-net
+        ssl_certificate_name: civil-sdt-commissioning-prod
         host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
@@ -50,7 +51,7 @@ gateways:
         add_ssl_profile: true
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
-        ssl_certificate_name: wildcard-platform-hmcts-net
+        ssl_certificate_name: civil-sdt-prod
         host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -16,6 +16,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: wildcard-platform-hmcts-net
+        host-name-prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
         listener_host_name_prefix: commissioning.sdt
@@ -50,6 +51,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: wildcard-platform-hmcts-net
+        host-name-prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
         listener_host_name_prefix: sdt

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -16,7 +16,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: wildcard-platform-hmcts-net
-        host-name-prefix: cft-mtls-api-mgmt-appgw
+        host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
         listener_host_name_prefix: commissioning.sdt
@@ -51,7 +51,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: wildcard-platform-hmcts-net
-        host-name-prefix: cft-mtls-api-mgmt-appgw
+        host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
         listener_host_name_prefix: sdt

--- a/environments/sbox/apim_appgw_config.yaml
+++ b/environments/sbox/apim_appgw_config.yaml
@@ -15,3 +15,5 @@ gateways:
         ssl_certificate_name: wildcard-sandbox-platform-hmcts-net
         host_name_suffix: sandbox.platform.hmcts.net
         ssl_host_name_suffix: sandbox.platform.hmcts.net
+        listener_host_name_suffix: sandbox.platform.hmcts.net
+        listener_ssl_host_name_suffix: sandbox.platform.hmcts.net

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -50,7 +50,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: civil-sdt-commissioning-nle
-        host-name-prefix: cft-mtls-api-mgmt-appgw
+        host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
         listener_host_name_prefix: sdtcomm
@@ -85,7 +85,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: civil-sdt-nle
-        host-name-prefix: cft-mtls-api-mgmt-appgw
+        host_name_prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
         listener_host_name_prefix: sdt

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -50,6 +50,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: civil-sdt-commissioning-nle
+        host-name-prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
         listener_host_name_prefix: sdtcomm
@@ -84,6 +85,7 @@ gateways:
         verify_client_cert_issuer_dn: true
         rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: civil-sdt-nle
+        host-name-prefix: cft-mtls-api-mgmt-appgw
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
         listener_host_name_prefix: sdt

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -9,31 +9,6 @@ gateways:
       - certificate_name: civil-sdt-commissioning-nle
       - certificate_name: civil-sdt-nle
     app_configuration:
-      - product: cft
-        component: api-mgmt-appgw
-        ssl_enabled: true
-        use_public_ip: true
-        health_path_override: "/status-0123456789abcdef"
-        ssl_certificate_name: wildcard-perftest-platform-hmcts-net
-        host_name_suffix: perftest.platform.hmcts.net
-        ssl_host_name_suffix: perftest.platform.hmcts.net
-        add_rewrite_rule: true
-        rewrite_rules:
-          - name: "SdtAddCustomHeadersRule"
-            sequence: "100"
-            request_headers:
-              - header_name: "CLIENT-IP-AGW"
-                header_value: "{var_client_ip}"
-              - header_name: "URI-PATH-AGW"
-                header_value: "{var_uri_path}"
-          - name: "SdtUrlRewriteRule"
-            sequence: "200"
-            conditions:
-              - variable: "var_uri_path"
-                pattern: ".*/producers(?>-comx)?/service/sdtapi"
-            url:
-              components: "path_only"
-              path: "/sdt-gateway"
       - product: cft-mtls
         component: api-mgmt-appgw
         ssl_enabled: true
@@ -45,6 +20,76 @@ gateways:
         ssl_certificate_name: wildcard-perftest-platform-hmcts-net
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
+        listener_host_name_suffix: perftest.platform.hmcts.net
+        listener_ssl_host_name_suffix: perftest.platform.hmcts.net
+        add_rewrite_rule: true
+        rewrite_rules:
+          - name: "SdtAddCustomHeadersRule"
+            sequence: "100"
+            request_headers:
+              - header_name: "CLIENT-IP-AGW"
+                header_value: "{var_client_ip}"
+              - header_name: "X-ARR-ClientCertSub-AGW"
+                header_value: "{var_client_certificate_subject}"
+              - header_name: "URI-PATH-AGW"
+                header_value: "{var_uri_path}"
+          - name: "SdtUrlRewriteRule"
+            sequence: "200"
+            conditions:
+              - variable: "var_uri_path"
+                pattern: ".*/producers(?>-comx)?/service/sdtapi"
+            url:
+              components: "path_only"
+              path: "/sdt-gateway"
+      - product: civil
+        component: sdt-commissioning
+        ssl_enabled: true
+        use_public_ip: true
+        health_path_override: "/status-0123456789abcdef"
+        add_ssl_profile: true
+        verify_client_cert_issuer_dn: true
+        rootca_certificate_name: civil_sdt_root_ca
+        ssl_certificate_name: civil-sdt-commissioning-nle
+        host_name_suffix: perftest.platform.hmcts.net
+        ssl_host_name_suffix: perftest.platform.hmcts.net
+        listener_host_name_prefix: sdtcomm
+        listener_host_name_suffix: apps-nle.hmcts.net
+        listener_ssl_host_name_suffix: apps-nle.hmcts.net
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.hmcts.net
+        add_rewrite_rule: true
+        rewrite_rules:
+          - name: "SdtAddCustomHeadersRule"
+            sequence: "100"
+            request_headers:
+              - header_name: "CLIENT-IP-AGW"
+                header_value: "{var_client_ip}"
+              - header_name: "X-ARR-ClientCertSub-AGW"
+                header_value: "{var_client_certificate_subject}"
+              - header_name: "URI-PATH-AGW"
+                header_value: "{var_uri_path}"
+          - name: "SdtUrlRewriteRule"
+            sequence: "200"
+            conditions:
+              - variable: "var_uri_path"
+                pattern: ".*/producers(?>-comx)?/service/sdtapi"
+            url:
+              components: "path_only"
+              path: "/sdt-gateway"
+      - product: civil
+        component: sdt
+        ssl_enabled: true
+        use_public_ip: true
+        health_path_override: "/status-0123456789abcdef"
+        add_ssl_profile: true
+        verify_client_cert_issuer_dn: true
+        rootca_certificate_name: civil_sdt_root_ca
+        ssl_certificate_name: civil-sdt-nle
+        host_name_suffix: perftest.platform.hmcts.net
+        ssl_host_name_suffix: perftest.platform.hmcts.net
+        listener_host_name_prefix: sdt
+        listener_host_name_suffix: apps-nle.hmcts.net
+        listener_ssl_host_name_suffix: apps-nle.hmcts.net
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.hmcts.net
         add_rewrite_rule: true
         rewrite_rules:
           - name: "SdtAddCustomHeadersRule"


### PR DESCRIPTION
### Jira link (if applicable)
SDT-183 (https://tools.hmcts.net/jira/browse/SDT-183)


### Change description ###
Switched application gateway component to use backend-http-settings-host-name branch of terraform-module-apim-application-gateway.  The branch will be merged once backend http setting host name changes have been confirmed.

Updated sandbox, perftest and production application gateway configuration files to use new properties added in terraform-module-apim-application-gateway backend-http-settings-host-name branch.  Production application gateway is not currently used by any applications, so changes to configuration will not affect anything.

Removed cft-api-mgmt-appgw entry from perftest application gateway configuration as it is not used.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
