### PR TITLE
Revert "removing app gw for prod 01"

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -19,7 +19,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
 
 
-cft_apps_cluster_ips            = ["10.90.79.250"]
+cft_apps_cluster_ips            = ["10.90.79.250", "10.90.95.250"]
 frontend_agw_private_ip_address = "10.90.96.12"
 frontend_agw_min_capacity       = 10
 frontend_agw_max_capacity       = 15


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#1959

adding app gw back for cft prod 01 after upgrade to version 1.28.

https://tools.hmcts.net/jira/browse/DTSPO-15844