### PR TITLE
Corrected backend host name in perftest App Gateway config

### DIFF
--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -56,7 +56,7 @@ gateways:
         listener_host_name_prefix: sdtcomm
         listener_host_name_suffix: apps-nle.hmcts.net
         listener_ssl_host_name_suffix: apps-nle.hmcts.net
-        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.hmcts.net
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.platform.hmcts.net
         add_rewrite_rule: true
         rewrite_rules:
           - name: "SdtAddCustomHeadersRule"
@@ -91,7 +91,7 @@ gateways:
         listener_host_name_prefix: sdt
         listener_host_name_suffix: apps-nle.hmcts.net
         listener_ssl_host_name_suffix: apps-nle.hmcts.net
-        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.hmcts.net
+        backend_host_name_override: cft-mtls-api-mgmt-appgw.perftest.platform.hmcts.net
         add_rewrite_rule: true
         rewrite_rules:
           - name: "SdtAddCustomHeadersRule"


### PR DESCRIPTION
### Jira link (if applicable)
SDT-183 (https://tools.hmcts.net/jira/browse/SDT-183)

### Change description ###
Added missing word to value of backend_host_name_override properties in perftest application gateway config file.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
