### PR TITLE
Change mode on WAF on nfdiv service from Detection to Prevention

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -24,4 +24,3 @@ frontends = [
     certificate_name_check_enabled = false
   }
 ]
-

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -462,7 +462,7 @@ frontends = [
   {
     product          = "nfdiv"
     name             = "nfdiv-civil-partnership"
-    mode             = "Detection"
+    mode             = "Prevention"
     custom_domain    = "www.end-civil-partnership.service.gov.uk"
     dns_zone_name    = "end-civil-partnership.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -462,7 +462,7 @@ frontends = [
   {
     product          = "nfdiv"
     name             = "nfdiv-civil-partnership"
-    mode             = "Prevention"
+    mode             = "Detection"
     custom_domain    = "www.end-civil-partnership.service.gov.uk"
     dns_zone_name    = "end-civil-partnership.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -681,7 +681,7 @@ frontends = [
   },
   {
     name           = "nfdiv"
-    mode           = "Detection"
+    mode           = "Prevention"
     custom_domain  = "nfdiv.aat.platform.hmcts.net"
     dns_zone_name  = "aat.platform.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
@@ -689,7 +689,7 @@ frontends = [
   },
   {
     name          = "nfdiv-apply"
-    mode          = "Detection"
+    mode          = "Prevention"
     custom_domain = "nfdiv-apply-for-divorce.aat.platform.hmcts.net"
     dns_zone_name = "aat.platform.hmcts.net"
     backend       = "nfdiv"
@@ -697,7 +697,7 @@ frontends = [
   },
   {
     name          = "nfdiv-civil"
-    mode          = "Detection"
+    mode          = "Prevention"
     custom_domain = "nfdiv-end-civil-partnership.aat.platform.hmcts.net"
     dns_zone_name = "aat.platform.hmcts.net"
     backend       = "nfdiv"


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/NFDIV-3888


### Change description ###
Platops have instructed each team to move to mode-Prevention for their web access firewall.

This change moves NFD to Prevention.