### PR TITLE
Testing CNAME validation_type to cname delgation rather than txt

### DIFF
--- a/components/shutter_static_webapp/static_webapp.tf
+++ b/components/shutter_static_webapp/static_webapp.tf
@@ -7,7 +7,7 @@ module "static_webapp" {
     azurerm.dnszone = azurerm.dnszone
   }
 
-  source              = "git::https://github.com/hmcts/terraform-module-shutter-static-webapp.git?ref=master"
+  source              = "git::https://github.com/hmcts/terraform-module-shutter-static-webapp.git?ref=thomast1906-patch-1"
   shutter_apps        = local.shutter_apps
   tags                = module.ctags.common_tags
   resource_group_name = azurerm_resource_group.rg.name


### PR DESCRIPTION
### Change description ###
Update static-webapp.tf to add custom domain validation to cname if required.

Currently the shutter dns solution we have sets the cname - not txt.
Example:
plum , CNAME = calm-rock-05d60e503.3.azurestaticapps.net
https://github.com/hmcts/terraform-module-shutter-static-webapp/pull/22