### PR TITLE
CUIRA-282 enable prevention mode in test env

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1687,6 +1687,7 @@ frontends = [
     name           = "cui-ra"
     custom_domain  = "cui-ra.perftest.platform.hmcts.net"
     dns_zone_name  = "perftest.platform.hmcts.net"
+    mode           = "Prevention"
     backend_domain = ["firewall-nonprodi-palo-cft-perftest.uksouth.cloudapp.azure.com"],
     global_exclusions = [
       {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CUIRA-282

### Change description ###

Enable waf prevention mode on test env. All other envs already have prevention mode
