### PR TITLE
Added et_sya_cookie_preferences as a global exclusion

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3323,7 +3323,7 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "et-sya-cookie-preferences"
-      },
+      }
     ]
     custom_rules = [
       {
@@ -3383,7 +3383,7 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "et-sya-cookie-preferences"
-      },
+      }
     ]
   },
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3041,6 +3041,13 @@ frontends = [
     dns_zone_name    = "claim-employment-tribunals.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]
     certificate_name = "claim-employment-tribunals-service-gov-uk"
+    global_exclusions = [
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "et-sya-cookie-preferences"
+      }
+    ]
   },
   {
     product          = "sptribs"
@@ -3142,11 +3149,6 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "_csrf"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "et-sya-cookie-preferences"
       }
     ]
   },

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3142,6 +3142,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "_csrf"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "et-sya-cookie-preferences"
       }
     ]
   },
@@ -3250,6 +3255,11 @@ frontends = [
         operator       = "Equals"
         selector       = "_ga"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "et-sya-cookie-preferences"
+      }
     ]
     custom_rules = [
       {
@@ -3307,6 +3317,11 @@ frontends = [
         operator       = "Equals"
         selector       = "_super_session"
       },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "et-sya-cookie-preferences"
+      },
     ]
     custom_rules = [
       {
@@ -3361,6 +3376,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "_app_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "et-sya-cookie-preferences"
       },
     ]
   },


### PR DESCRIPTION
### Jira link (if applicable)

There is no Jira link - An update required to bypass Firewall check for et_sya_cookie_preferences (https://moj.enterprise.slack.com/archives/C06R9LR05JQ/p1711617241062239)

### Change description ###

et-sya-cookie-preferences added as global exclusion to the following custom domain, dns zone pairs:

1. employmenttribunals.service.gov.uk, employmenttribunals-service-gov-uk
2. admin.employmenttribunals.service.gov.uk, employmenttribunals-service-gov-uk
3. tribunal-response.employmenttribunals.service.gov.uk, employmenttribunals-service-gov-uk
4. claim-employment-tribunals-service-gov-uk, claim-employment-tribunals-service-gov-uk

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
