### PR TITLE
DTSPO-16594 - remove 01 cluster to upgrade

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -22,7 +22,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.10.161.102"
-cft_apps_cluster_ips            = ["10.10.143.250", "10.10.159.250"]
+cft_apps_cluster_ips            = ["10.10.143.250"]
 
 publisher_email = "DTSPlatformOps@HMCTS.NET"
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16594

### Change description ###

Remove 01 cluster from appgateway for upgrade


## 🤖GIPPI PR SUMMARY🤖


The pull request removed one IP address from the `cft_apps_cluster_ips` list in the `stg.tfvars` file and updated the `publisher_email` to \"DTSPlatformOps@HMCTS.NET\". 🔄🔑