### PR TITLE
DTSPO-16594 - perftest 00 cluster remove from appgateway

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -21,7 +21,7 @@ shutter_apps = [
 
 cft_apps_ag_ip_address          = "10.48.96.123"
 frontend_agw_private_ip_address = "10.48.96.113"
-cft_apps_cluster_ips            = ["10.48.79.250", "10.48.95.250"]
+cft_apps_cluster_ips            = ["10.48.95.250"]
 
 hub                           = "nonprod"
 key_vault_subscription        = "8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16594

### Change description ###

REmoved 00 cluster for upgrade for perftest environment



## 🤖GIPPI PR SUMMARY🤖


- Removed an IP address from the `cft_apps_cluster_ips` list in `test.tfvars`
- Updated the `cft_apps_ag_ip_address` and `frontend_agw_private_ip_address` values in `test.tfvars`
- Changed the value of `hub` to \"nonprod\" and `key_vault_subscription` to \"8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c\" in `test.tfvars`