### PR TITLE
DTSPO-16594 - perftest 01 cluster remove from appgateway

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -21,7 +21,7 @@ shutter_apps = [
 
 cft_apps_ag_ip_address          = "10.48.96.123"
 frontend_agw_private_ip_address = "10.48.96.113"
-cft_apps_cluster_ips            = ["10.48.79.250", "10.48.95.250"]
+cft_apps_cluster_ips            = ["10.48.79.250"]
 
 hub                           = "nonprod"
 key_vault_subscription        = "8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16594

### Change description ###

Remove 01 cluster from application gateway





## 🤖GIPPI PR SUMMARY🤖


The pull request modifies the `test.tfvars` file in the `test` environment.

- Removed an IP address from `cft_apps_cluster_ips`.
- Updates the values of `cft_apps_ag_ip_address` and `frontend_agw_private_ip_address`.
- Updates the value of `hub`.
- Updates the value of `key_vault_subscription`.
- A single IP address remained in `cft_apps_cluster_ips`.
