### PR TITLE
DTSPO-16595 - remove prod 00 cluster from appgateway

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   repositories:
   - repository: cnp-azuredevops-libraries
     type: github
-    ref: refs/heads/master
+    ref: refs/heads/test-tfswitch
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
 

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -11,7 +11,7 @@ resources:
   repositories:
   - repository: cnp-azuredevops-libraries
     type: github
-    ref: refs/heads/test-tfswitch
+    ref: refs/heads/master
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
 

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -19,7 +19,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
 
 
-cft_apps_cluster_ips            = ["10.90.79.250", "10.90.95.250"]
+cft_apps_cluster_ips            = ["10.90.95.250"]
 frontend_agw_private_ip_address = "10.90.96.12"
 frontend_agw_min_capacity       = 10
 frontend_agw_max_capacity       = 15


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16595

### Change description ###

Remove prod 00 cluster from application gateway







## 🤖GIPPI PR SUMMARY🤖


- Removed one IP address from the cft_apps_cluster_ips array in prod.tfvars
- Updated the frontend_agw_private_ip_address in prod.tfvars from \"10.90.96.15\" to \"10.90.96.12\"