### PR TITLE
Revert "DTSPO-16595 - remove prod 00 cluster from appgateway"

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -19,7 +19,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
 
 
-cft_apps_cluster_ips            = ["10.90.95.250"]
+cft_apps_cluster_ips            = ["10.90.79.250", "10.90.95.250"]
 frontend_agw_private_ip_address = "10.90.96.12"
 frontend_agw_min_capacity       = 10
 frontend_agw_max_capacity       = 15


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2090

## 🤖GIPPI PR SUMMARY🤖


- Updated the prod.tfvars file in the prod environment
- Changed the cft_apps_cluster_ips from a single IP to a list of two IPs
- Added a new IP address to the cft_apps_cluster_ips list