### PR TITLE
DTSPO-16595 - remove prod 01 cluster from appgateway

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -19,7 +19,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
 
 
-cft_apps_cluster_ips            = ["10.90.79.250", "10.90.95.250"]
+cft_apps_cluster_ips            = ["10.90.79.250"]
 frontend_agw_private_ip_address = "10.90.96.12"
 frontend_agw_min_capacity       = 10
 frontend_agw_max_capacity       = 15


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16595

### Change description ###
Remove 01 cluster form application gateway



## 🤖GIPPI PR SUMMARY🤖


The changes in this pull request are:

- Removed an IP address from the cft_apps_cluster_ips list in prod.tfvars
- Updated the frontend_agw_private_ip_address to \"10.90.96.12\" in prod.tfvars