### PR TITLE
migrate apim back to original resources

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -4,7 +4,7 @@ env          = "ithc"
 subscription = "ithc"
 
 migration_variables = {
-  trigger_migration            = true
+  trigger_migration            = false
   trigger_migration_temp_pip   = true
   temp_subnet_address_prefixes = "10.11.226.0/24"
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17759

### Change description ###
changed migration trigger to false to revert apim instance back to original resources

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Changed file: `ithc.tfvars`
- Set `trigger_migration` to `false` instead of `true`
- Updated `trigger_migration_temp_pip` to `true`
- Updated `temp_subnet_address_prefixes` to \"10.11.226.0/24\"