### PR TITLE
added cookie preferences and ga

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3108,6 +3108,16 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "cui-ra-cookie-preferences"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "StartsWith"
+        selector       = "_ga_"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "dtCookie"
       },
       {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3826,6 +3826,16 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "cui-ra-cookie-preferences"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "StartsWith"
+        selector       = "_ga_"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "dtCookie"
       },
       {

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -3038,6 +3038,16 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "cui-ra-cookie-preferences"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "StartsWith"
+        selector       = "_ga_"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "dtCookie"
       },
       {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2113,6 +2113,16 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "cui-ra-cookie-preferences"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "StartsWith"
+        selector       = "_ga_"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "dtCookie"
       },
       {


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/CUIRA-370

### Change description ###

added 2 new cookies. one for cookie preference and the other to allow google analytics

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added new configurations for matching request cookie names and operators.
- Added selectors for \"cui-ra-cookie-preferences\" and \"_ga_\".

### environments/prod/prod.tfvars
- Added new configurations for matching request cookie names and operators.
- Added selectors for \"cui-ra-cookie-preferences\" and \"_ga_\".

### environments/stg/stg.tfvars
- Added new configurations for matching request cookie names and operators.
- Added selectors for \"cui-ra-cookie-preferences\" and \"_ga_\".

### environments/test/test.tfvars
- Added new configurations for matching request cookie names and operators.
- Added selectors for \"cui-ra-cookie-preferences\" and \"_ga_\".