### PR TITLE
increase timeout for apim upgrades

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -17,7 +17,7 @@ resources:
 
 variables:
   - name: timeoutInMinutes
-    value: 60
+    value: 90
   - name: agentPool
     value: 'ubuntu-latest'
   - name: build


### PR DESCRIPTION
### Jira link (if applicable)

### Change description ###
increase pipeline timeout to 90 min to avoid apim upgrade timeout

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


md
azure_pipeline.yaml
- Increased the value of the timeoutInMinutes variable from 60 to 90.
```