### PR TITLE
revert pipeline timeout back to 60 minutes

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -17,7 +17,7 @@ resources:
 
 variables:
   - name: timeoutInMinutes
-    value: 90
+    value: 60
   - name: agentPool
     value: 'ubuntu-latest'
   - name: build


### PR DESCRIPTION
### Jira link (if applicable)


### Change description ###
updated pipeline timeout from 90 -> 60 minutes

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


md
azure_pipeline.yaml
- Changed the value of timeoutInMinutes variable from 90 to 60
```