### PR TITLE
revert apim appgw perftest to default

### DIFF
--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -14,31 +14,9 @@ gateways:
         ssl_enabled: true
         use_public_ip: true
         health_path_override: "/status-0123456789abcdef"
-        add_ssl_profile: true
-        verify_client_cert_issuer_dn: true
-        rootca_certificate_name: civil_sdt_root_ca
         ssl_certificate_name: wildcard-perftest-platform-hmcts-net
         host_name_suffix: perftest.platform.hmcts.net
         ssl_host_name_suffix: perftest.platform.hmcts.net
-        add_rewrite_rule: true
-        rewrite_rules:
-          - name: "SdtAddCustomHeadersRule"
-            sequence: "100"
-            request_headers:
-              - header_name: "CLIENT-IP-AGW"
-                header_value: "{var_client_ip}"
-              - header_name: "X-ARR-ClientCertSub-AGW"
-                header_value: "{var_client_certificate_subject}"
-              - header_name: "URI-PATH-AGW"
-                header_value: "{var_uri_path}"
-          - name: "SdtUrlRewriteRule"
-            sequence: "200"
-            conditions:
-              - variable: "var_uri_path"
-                pattern: ".*/producers(?>-comx)?/service/sdtapi"
-            url:
-              components: "path_only"
-              path: "/sdt-gateway"
       - product: civil
         component: sdt-commissioning
         ssl_enabled: true


### PR DESCRIPTION
### Change description ###
revert apim appgw perftest to default

## 🤖AEP PR SUMMARY🤖


- File **apim_appgw_config.yaml**:
  - Removed several lines related to adding SSL profile, verifying client certificate issuer DN, root CA certificate, rewrite rules, and conditions.
  - Updated **ssl_enabled** to true.