### PR TITLE
Unblock pcq returnUrl rule for demo.

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1253,6 +1253,11 @@ frontends = [
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
     global_exclusions = [
       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "returnUrl"
+      },
+      {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "connect.sid"


### PR DESCRIPTION
### Jira link (if applicable)
Unblock pcq returnUrl rule for demo.


### Change description ###
The rule is not applied to demo only

## 🤖AEP PR SUMMARY🤖


- The file demo.tfvars``` was modified to include a new global exclusion for QueryStringArgNames matching \"returnUrl\".
- The change adds a new item to the global_exclusions list within the file.