### PR TITLE
Added cookie exclusion to demo admin for et

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -2855,6 +2855,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "_super_session"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "et-sya-cookie-preferences"
       }
     ]


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

The admin for pet-et is not accessible.  This because the cookie isn't allowed.

This changes fixes it

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **demo.tfvars**
  - Added global exclusion for \"_super_session\" in the frontends configuration.