### PR TITLE
correct apim-appgw module ref to main

### DIFF
--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -27,7 +27,7 @@ module "app-gw" {
     azurerm.kv  = azurerm.kv
   }
 
-  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=master"
+  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=main"
   yaml_path                                    = "${path.cwd}/../../environments/${local.env}/apim_appgw_config.yaml"
   env                                          = local.dns_zone
   location                                     = var.location

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -27,7 +27,7 @@ module "app-gw" {
     azurerm.kv  = azurerm.kv
   }
 
-  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=allow-multiple-certs-on-listener"
+  source                                       = "git::https://github.com/hmcts/terraform-module-apim-application-gateway.git?ref=master"
   yaml_path                                    = "${path.cwd}/../../environments/${local.env}/apim_appgw_config.yaml"
   env                                          = local.dns_zone
   location                                     = var.location


### PR DESCRIPTION
### Change description ###

- correct apim-appgw module ref to master


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Updated `main.tf`: Changed the source of the module \"app-gw\" from \"allow-multiple-certs-on-listener\" branch to \"main\".