### PR TITLE
add exela root ca cert to cft-mtls listener

### DIFF
--- a/components/apim-appgw/root_certs.tf
+++ b/components/apim-appgw/root_certs.tf
@@ -5,9 +5,7 @@ locals {
     test = {
       civil_sdt_root_ca   = "civil-sdt-root-ca"
       reform_scan_sscs_ca = "reform-scan-sscs-ca"
-      dts_bsp_team_ca     = "dts-bsp-team-ca"
       exela_uat_ca        = "exela-uat-ca"
-      iron_mountain_ca    = "iron-mountain-ca"
     }
     prod = {
       civil_sdt_root_ca = "civil-sdt-root-ca"

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -21,6 +21,7 @@ gateways:
         add_ssl_profile: true
         rootca_certificates:
          - rootca_certificate_name: reform_scan_sscs_ca
+         - rootca_certificate_name: exela_uat_ca
         add_rewrite_rule: true
         rewrite_rules:
           - name: "AddCustomHeadersRule"


### PR DESCRIPTION
### Change description ###

- add exela root ca to cft-mtls listener for reform scan
- remove iron mountain & duplicate reform-scan-ca from mapping of root ca certs


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated the `root_certs.tf` file:
  - Removed `dts_bsp_team_ca` and `iron_mountain_ca`.

- Updated the `apim_appgw_config.yaml` file in the test environment:
  - Added `exela_uat_ca` to the `rootca_certificates` section.