### PR TITLE
perftest: remove exela root ca cert to cft-mtls listener

### DIFF
--- a/components/apim-appgw/root_certs.tf
+++ b/components/apim-appgw/root_certs.tf
@@ -5,7 +5,6 @@ locals {
     test = {
       civil_sdt_root_ca   = "civil-sdt-root-ca"
       reform_scan_sscs_ca = "reform-scan-sscs-ca"
-      exela_uat_ca        = "exela-uat-ca"
     }
     prod = {
       civil_sdt_root_ca = "civil-sdt-root-ca"

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -21,7 +21,6 @@ gateways:
         add_ssl_profile: true
         rootca_certificates:
          - rootca_certificate_name: reform_scan_sscs_ca
-         - rootca_certificate_name: exela_uat_ca
         add_rewrite_rule: true
         rewrite_rules:
           - name: "AddCustomHeadersRule"


### PR DESCRIPTION
### Change description ###

- exela cert still invalid and missing CA: True


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated `root_certs.tf`: Removed `exela_uat_ca` from the `test` section in the `locals` block.
- Updated `apim_appgw_config.yaml`: Removed `exela_uat_ca` from the `rootca_certificates` list.