### PR TITLE
Change from detection to prevention mode.

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1071,7 +1071,7 @@ frontends = [
   },
   {
     name           = "civil-citizen-ui"
-    mode           = "Detection"
+    mode           = "Prevention"
     custom_domain  = "moneyclaims.demo.platform.hmcts.net"
     dns_zone_name  = "demo.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
@@ -1079,11 +1079,57 @@ frontends = [
   },
   {
     name           = "cmc"
-    mode           = "Detection"
+    mode           = "Prevention"
     custom_domain  = "moneyclaims1.demo.platform.hmcts.net"
     dns_zone_name  = "demo.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
-
+    global_exclusions = [
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "SESSION_ID"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "iss"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "signerRole"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "reason"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "rows"
+      },
+    ]
   },
   {
     name           = "nfdiv"


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSCCI-525

### Change description ###

Enable Waf changing mode from detection to prevention in Demo for Cmc & Citizen-ui

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Changed mode of \"civil-citizen-ui\" to \"Prevention\" from \"Detection\"
- Added global exclusions for \"cmc\" including match_variable, operator, and selector 