### PR TITLE
Block requests for CFT APIM if URI contains

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2088,8 +2088,8 @@ frontends = [
         match_conditions = [
           {
             match_variable = "RequestUri"
-             operator      = "Contains"
-             values        = ["/reform-scan"]
+            operator       = "Contains"
+            values         = ["/reform-scan"]
           }
         ]
       },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2087,9 +2087,10 @@ frontends = [
         action   = "Block"
         match_conditions = [
           {
-            match_variable = "RequestUri"
-            operator       = "Contains"
-            match_values   = ["/reform-scan"]
+            match_variable     = "RequestUri"
+            operator           = "Contains"
+            negation_condition = false
+            match_values       = ["/reform-scan"]
           }
         ]
       },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2078,6 +2078,22 @@ frontends = [
     backend_domain   = ["firewall-nonprodi-palo-cftapimgmtperftest.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-perftest-platform-hmcts-net"
     cache_enabled    = "false"
+
+    custom_rules = [
+      {
+        name     = "BlockReformScanEndpoint"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable = "RequestUri"
+             operator      = "Contains"
+             values        = ["/reform-scan"]
+          }
+        ]
+      },
+    ],
   },
   {
     name           = "adoption-web"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2089,7 +2089,7 @@ frontends = [
           {
             match_variable = "RequestUri"
             operator       = "Contains"
-            values         = ["/reform-scan"]
+            match_values   = ["/reform-scan"]
           }
         ]
       },


### PR DESCRIPTION
### Change description ###

Block CFT APIM requests if reform-scan is in the path, these requests should only go through mtls appgw setup.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- Modified `test.tfvars`: Added a custom rule to block requests containing \"/reform-scan\" for the \"adoption-web\" frontend.