### PR TITLE
Block request if reform-scan for CFT APIM

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -38,6 +38,23 @@ frontends = [
     backend_domain   = ["firewall-nonprodi-palo-cftapimgmtdemo.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
     cache_enabled    = "false"
+
+    custom_rules = [
+      {
+        name     = "BlockReformScanEndpoint"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RequestUri"
+            operator           = "Contains"
+            negation_condition = false
+            match_values       = ["/reform-scan"]
+          }
+        ]
+      },
+    ],
   },
   {
     product          = "plum-public"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -1869,6 +1869,23 @@ frontends = [
     backend_domain   = ["firewall-nonprodi-palo-cftapimgmtithc.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-ithc-platform-hmcts-net"
     cache_enabled    = "false"
+
+    custom_rules = [
+      {
+        name     = "BlockReformScanEndpoint"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RequestUri"
+            operator           = "Contains"
+            negation_condition = false
+            match_values       = ["/reform-scan"]
+          }
+        ]
+      },
+    ],
   },
   {
     name           = "paymentoutcome-web"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2518,6 +2518,23 @@ frontends = [
     certificate_name = "wildcard-platform-hmcts-net"
     cache_enabled    = "false"
     shutter_app      = false
+
+    custom_rules = [
+      {
+        name     = "BlockReformScanEndpoint"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RequestUri"
+            operator           = "Contains"
+            negation_condition = false
+            match_values       = ["/reform-scan"]
+          }
+        ]
+      },
+    ],
   },
   {
     product          = "fact"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -3175,6 +3175,23 @@ frontends = [
     backend_domain   = ["firewall-prod-int-palo-cftapimgmtstg.uksouth.cloudapp.azure.com"]
     certificate_name = "cft-api-mgmt-aat-platform-hmcts-net"
     cache_enabled    = "false"
+
+    custom_rules = [
+      {
+        name     = "BlockReformScanEndpoint"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RequestUri"
+            operator           = "Contains"
+            negation_condition = false
+            match_values       = ["/reform-scan"]
+          }
+        ]
+      },
+    ],
   },
   {
     name           = "paymentoutcome-web"


### PR DESCRIPTION
### Change description ###

Already applied and tested in perftest. Applying to rest of envs. Blocking requests if reform-scan endpoint as all requests should come through the appgw mtls url. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added custom rule to block requests containing \"/reform-scan\" to the firewall configuration.

### environments/ithc/ithc.tfvars
- Added custom rule to block requests containing \"/reform-scan\" to the firewall configuration.

### environments/prod/prod.tfvars
- Added custom rule to block requests containing \"/reform-scan\" to the firewall configuration.

### environments/stg/stg.tfvars
- Added custom rule to block requests containing \"/reform-scan\" to the firewall configuration.