### PR TITLE
FACT-1846 - added some missing exclusion rules and rule alterations for non prod

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -498,6 +498,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "additionalLinks"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "secondaryAddress"
       }
     ]
   },

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -452,7 +452,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "info_"
+        selector       = "info"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -461,23 +461,23 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "areaOfLaw[external_link]"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "courtFacilities[1][description]"
+        operator       = "StartsWith"
+        selector       = "areaOfLaw"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "alert_"
+        selector       = "courtFacilities"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "sc_intro_paragraph_"
+        selector       = "alert"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "sc_intro_paragraph"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -493,6 +493,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "progression"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "additionalLinks"
       }
     ]
   },

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -776,7 +776,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "info_"
+        selector       = "info"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -785,23 +785,23 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "areaOfLaw[external_link]"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "courtFacilities[1][description]"
+        operator       = "StartsWith"
+        selector       = "areaOfLaw"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "alert_"
+        selector       = "courtFacilities"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "sc_intro_paragraph_"
+        selector       = "alert"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "sc_intro_paragraph"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -817,6 +817,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "progression"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "additionalLinks"
       }
     ]
   },

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -822,6 +822,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "additionalLinks"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "secondaryAddress"
       }
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -948,6 +948,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "additionalLinks"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "secondaryAddress"
       }
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -902,7 +902,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "info_"
+        selector       = "info"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -911,23 +911,23 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "areaOfLaw[external_link]"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "courtFacilities[1][description]"
+        operator       = "StartsWith"
+        selector       = "areaOfLaw"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "alert_"
+        selector       = "courtFacilities"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "sc_intro_paragraph_"
+        selector       = "alert"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "sc_intro_paragraph"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -943,6 +943,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "progression"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "additionalLinks"
       }
     ]
   },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -634,6 +634,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "additionalLinks"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "secondaryAddress"
       }
     ]
   },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -588,7 +588,7 @@ frontends = [
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "info_"
+        selector       = "info"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -597,23 +597,23 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "areaOfLaw[external_link]"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "courtFacilities[1][description]"
+        operator       = "StartsWith"
+        selector       = "areaOfLaw"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "alert_"
+        selector       = "courtFacilities"
       },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
-        selector       = "sc_intro_paragraph_"
+        selector       = "alert"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "sc_intro_paragraph"
       },
       {
         match_variable = "RequestBodyPostArgNames"
@@ -629,6 +629,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "StartsWith"
         selector       = "progression"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "StartsWith"
+        selector       = "additionalLinks"
       }
     ]
   },


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/FACT-1846

### Change description ###
added missing bits into fact admin

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- Modified environments/demo/demo.tfvars, environments/ithc/ithc.tfvars, environments/stg/stg.tfvars, environments/test/test.tfvars:
  - Updated multiple instances of the 'selector' attribute values from ending with \"_\" to starting with the same text, and changed the 'operator' from 'Equals' to 'StartsWith' for some 'selector' values. Added new objects for 'additionalLinks' and 'secondaryAddress' with 'StartsWith' operator.