### PR TITLE
PAY-6602: Update priority so it doesn't clash with BlockReformScanEnd…

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -56,7 +56,7 @@ frontends = [
       },
       {
         name     = "BlockFeeAndPaymentEndpoints"
-        priority = 1
+        priority = 2
         type     = "MatchRule"
         action   = "Block"
         match_conditions = [

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2216,7 +2216,7 @@ frontends = [
       },
       {
         name     = "BlockFeeAndPaymentEndpoints"
-        priority = 1
+        priority = 2
         type     = "MatchRule"
         action   = "Block"
         match_conditions = [

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2561,7 +2561,7 @@ frontends = [
       },
       {
         name     = "BlockFeeAndPaymentEndpoints"
-        priority = 1
+        priority = 2
         type     = "MatchRule"
         action   = "Block"
         match_conditions = [

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -3348,7 +3348,7 @@ frontends = [
       },
       {
         name     = "BlockFeeAndPaymentEndpoints"
-        priority = 1
+        priority = 2
         type     = "MatchRule"
         action   = "Block"
         match_conditions = [

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2241,7 +2241,7 @@ frontends = [
       },
       {
         name     = "BlockFeeAndPaymentEndpoints"
-        priority = 1
+        priority = 2
         type     = "MatchRule"
         action   = "Block"
         match_conditions = [


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/PAY-6602


### Change description ###
Lower priority as it appears to be clashing with another custom rule for the same product. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The priority of a rule named \"BlockFeeAndPaymentEndpoints\" has been updated from 1 to 2 in all environment tfvars files (demo, ithc, prod, stg, test). This will change the execution order of the rule within the application.