### PR TITLE
Adding PCIPal cert to prod app gateway

### DIFF
--- a/components/apim-appgw/root_certs.tf
+++ b/components/apim-appgw/root_certs.tf
@@ -24,6 +24,7 @@ locals {
       liberata_ca         = "liberata-ca"
       exela_ca            = "exela-ca"
       reform_scan_sscs_ca = "reform-scan-sscs-ca"
+      pcipal_ca           = "pcipal-ca"
     }
   }
 

--- a/components/apim-appgw/root_certs.tf
+++ b/components/apim-appgw/root_certs.tf
@@ -12,6 +12,7 @@ locals {
       reform_scan_sscs_ca = "reform-scan-sscs-ca"
       liberata_ca         = "liberata-ca"
       exela_ca            = "exela-ca"
+      pcipal_ca           = "pcipal-ca"
     }
     stg = {
       reform_scan_sscs_ca = "reform-scan-sscs-ca"

--- a/environments/demo/apim_appgw_config.yaml
+++ b/environments/demo/apim_appgw_config.yaml
@@ -21,6 +21,7 @@ gateways:
          - rootca_certificate_name: reform_scan_sscs_ca
          - rootca_certificate_name: liberata_ca
          - rootca_certificate_name: exela_ca
+         - rootca_certificate_name: pcipal_ca
         add_rewrite_rule: true
         rewrite_rules:
           - name: "AddCustomHeadersRule"

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -23,6 +23,7 @@ gateways:
          - rootca_certificate_name: liberata_ca
          - rootca_certificate_name: exela_ca
          - rootca_certificate_name: reform_scan_sscs_ca
+         - rootca_certificate_name: pcipal_ca
         add_rewrite_rule: true
         rewrite_rules:
           - name: "AddCustomHeadersRule"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-18581

### Change description
Adding PCIPal cert to the prod APIM appGW
### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- `components/apim-appgw/root_certs.tf` added a new local variable `pcipal_ca` for PCIPal CA.
- `environments/prod/apim_appgw_config.yaml` added `rootca_certificate_name: pcipal_ca` under the gateways section.