### PR TITLE
Revert "DTSCCI-525 Update Exclusion rules to match other environments"

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1149,24 +1149,33 @@ frontends = [
     certificate_name = "moneyclaims-service-gov-uk"
     disabled_rules = {
       SQLI = [
+        "942100",
+        "942110",
+        "942150",
         "942200",
+        "942210",
+        "942230",
         "942260",
+        "942300",
+        "942310",
+        "942330",
         "942340",
+        "942361",
         "942370",
+        "942380",
+        "942390",
+        "942400",
+        "942410",
         "942430",
-        "942440",
         "942450",
       ]
-      LFI = [
-        "930100",
-        "930130"
-      ]
       RCE = [
-        "932100",
-        "932115"
+        "932105",
+        "932115",
+        "932150",
       ]
-      RFI = [
-        "931130"
+      PROTOCOL-ATTACK = [
+        "921110"
       ]
     }
     global_exclusions = [
@@ -1215,32 +1224,8 @@ frontends = [
         operator       = "StartsWith"
         selector       = "rows"
       },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "cmc-cookie-preferences"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "citizen-ui-session"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "\\'analytics\\'"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "\\'apm\\'"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "money-claims-cookie-preferences"
-      },
     ]
+
   },
   {
     product          = "cmc"
@@ -1252,24 +1237,33 @@ frontends = [
     certificate_name = "moneyclaims-service-gov-uk"
     disabled_rules = {
       SQLI = [
+        "942100",
+        "942110",
+        "942150",
         "942200",
+        "942210",
+        "942230",
         "942260",
+        "942300",
+        "942310",
+        "942330",
         "942340",
+        "942361",
         "942370",
+        "942380",
+        "942390",
+        "942400",
+        "942410",
         "942430",
-        "942440",
         "942450",
       ]
-      LFI = [
-        "930100",
-        "930130"
-      ]
       RCE = [
-        "932100",
-        "932115"
+        "932105",
+        "932115",
+        "932150",
       ]
-      RFI = [
-        "931130"
+      PROTOCOL-ATTACK = [
+        "921110"
       ]
     }
     global_exclusions = [
@@ -1315,25 +1309,11 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "StartsWith"
         selector       = "rows"
       },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "cmc-cookie-preferences"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "\\'analytics\\'"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "\\'apm\\'"
-      },
     ]
+
   },
   {
     product          = "cmc"


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2224

Reverting PR to update rules for Prod as It is creating issues for Users 



## 🤖AEP PR SUMMARY🤖


### environments/prod/prod.tfvars
- Updated the disabled_rules for SQL injection and remote code execution for two frontends.
- Removed several global exclusions and modified one to have a different operator for a specific match_variable.