### PR TITLE
IDAM: Exclude new cookies from WAF analysis

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -2608,6 +2608,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -445,6 +445,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -2213,6 +2213,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -356,6 +356,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -2351,6 +2351,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1247,6 +1247,16 @@ frontends = [
         selector       = "Idam.Session"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Reset"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Register"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"


### PR DESCRIPTION
### Jira link
N/A

### Change description
We have introduced new cookies in HMCTS-Access that are used to story state for user journeys:
* "Idam.Reset"
* "Idam.Registration"
The cookie values are base64 encoded and occasionally get flagged by WAF as malicious. This PR excludes the new cookies from the WAF analysis.

### Testing done
N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change














## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.

### environments/ithc/ithc.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.

### environments/prod/prod.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.

### environments/sbox/sbox.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.

### environments/stg/stg.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.

### environments/test/test.tfvars
- Added new match_variable, operator, and selector entries for RequestCookieNames.