### PR TITLE
DTSPB-4265 update operator of executorName for WAF exclusion

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1971,7 +1971,7 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "executorName"
       }
     ]

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -1612,7 +1612,7 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "executorName"
       }
     ]

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1697,7 +1697,7 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "executorName"
       }
     ]

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -1781,7 +1781,7 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "executorName"
       }
     ]

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1452,7 +1452,7 @@ frontends = [
       },
       {
         match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
+        operator       = "Contains"
         selector       = "executorName"
       }
     ]


### PR DESCRIPTION
### Jira link
DTSPB-4265

### Change description
update operator of executorName for WAF exclusion
related to INC5643023

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Changed operator from \"Equals\" to \"Contains\" for match_variable \"RequestBodyPostArgNames\" at line 1971.

### environments/ithc/ithc.tfvars
- Changed operator from \"Equals\" to \"Contains\" for match_variable \"RequestBodyPostArgNames\" at line 1612.

### environments/prod/prod.tfvars
- Changed operator from \"Equals\" to \"Contains\" for match_variable \"RequestBodyPostArgNames\" at line 1697.

### environments/stg/stg.tfvars
- Changed operator from \"Equals\" to \"Contains\" for match_variable \"RequestBodyPostArgNames\" at line 1781.

### environments/test/test.tfvars
- Changed operator from \"Equals\" to \"Contains\" for match_variable \"RequestBodyPostArgNames\" at line 1452.