### PR TITLE
Upgrade CFT Prod AKS Clusters to Kubernetes 1.30 - re-add cft-prod-00-aks IP 

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -19,7 +19,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
 
 
-cft_apps_cluster_ips            = ["10.90.95.250"]
+cft_apps_cluster_ips            = ["10.90.79.250", "10.90.95.250"]
 frontend_agw_private_ip_address = "10.90.96.12"
 frontend_agw_min_capacity       = 10
 frontend_agw_max_capacity       = 15


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2279

## 🤖AEP PR SUMMARY🤖


### environments/prod/prod.tfvars
- Modified `cft_apps_cluster_ips` from `[\"10.90.95.250\"]` to `[\"10.90.79.250\", \"10.90.95.250\"]` 🔄.