### PR TITLE
Exclude cookies_policy cookie in idam-hmcts-access

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -2749,6 +2749,11 @@ frontends = [
         selector       = "connect.sid"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookies_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -460,6 +460,11 @@ frontends = [
         selector       = "connect.sid"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookies_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -371,6 +371,11 @@ frontends = [
         selector       = "connect.sid"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookies_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -2534,6 +2534,11 @@ frontends = [
         selector       = "connect.sid"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookies_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1298,6 +1298,11 @@ frontends = [
         selector       = "connect.sid"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookies_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"


### PR DESCRIPTION
### Jira link

N/A

### Change description

Exclude cookies_policy cookie in idam-hmcts-access

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added a new configuration for `RequestCookieNames` matching the operator \"Equals\" and selector \"cookies_policy\" to the frontends array.

### environments/ithc/ithc.tfvars
- Added a new configuration for `RequestCookieNames` matching the operator \"Equals\" and selector \"cookies_policy\" to the frontends array.

### environments/sbox/sbox.tfvars
- Added a new configuration for `RequestCookieNames` matching the operator \"Equals\" and selector \"cookies_policy\" to the frontends array.

### environments/stg/stg.tfvars
- Added a new configuration for `RequestCookieNames` matching the operator \"Equals\" and selector \"cookies_policy\" to the frontends array.

### environments/test/test.tfvars
- Added a new configuration for `RequestCookieNames` matching the operator \"Equals\" and selector \"cookies_policy\" to the frontends array.