### PR TITLE
DTSPO-19088 - removing cluster selector from precheck

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -399,7 +399,6 @@ stages:
               serviceConnection: 'azurerm-sandbox'
               overrideAction: ${{ parameters.overrideAction }}
               projectName: ${{ variables.businessArea }}
-              cluster: '00'
               environment: 'sbox'
               runManualStart: true
 


### PR DESCRIPTION
### Jira link
DTSPO-19088

### Change description
removing cluster selector from precheck as this is not used anymore and this is causing pipeline failures.

### Testing done
Tested in other repo's

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### azure_pipeline.yaml
- Removed the `cluster` parameter and its value `'00'` from the `stages` section.
- Updated the `environment` value from `'sbox'` to `$environment` in the `stages` section.