### PR TITLE
Exclude Idam.Request cookie in idam-hmcts-access

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -2746,6 +2746,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "connect.sid"
       },
       {

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -457,6 +457,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "connect.sid"
       },
       {

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -368,6 +368,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "connect.sid"
       },
       {

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -2521,6 +2521,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "connect.sid"
       },
       {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -1295,6 +1295,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "connect.sid"
       },
       {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SIDM-9508

### Change description

Exclude Idam.Request cookie in idam-hmcts-access

### Testing done

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The changes in the pull request involve adding a new block of configuration to the \"demo.tfvars\", \"ithc.tfvars\", \"sbox.tfvars\", \"stg.tfvars\", and \"test.tfvars\" files. 
- The added config block sets \"match_variable\" to \"RequestCookieNames\", \"operator\" to \"Equals\", and \"selector\" to \"Idam.Request\".