### PR TITLE
adding import block for error on pipeline

### DIFF
--- a/components/import/import.tf
+++ b/components/import/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = module.api-mgmt.azurerm_api_management_custom_domain.api-management-custom-domain
+  id = "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourceGroups/cft-aat-network-rg/providers/Microsoft.ApiManagement/service/cft-api-mgmt-stg"
+}


### PR DESCRIPTION
### Jira link

[DTSPO-22362](https://tools.hmcts.net/jira/browse/DTSPO-22362)

### Change description

Pipeline [failing](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=690815&view=logs&j=ca7c59f8-2622-5aaf-fa4b-c47d65ab55cb&t=fbf48a17-7161-57e1-d799-e4ec7a7b3670) do to a resource needing to be imported.  

adding a import file to resolve this

