### PR TITLE
Update ithc.tfvars front door config for front end(pcs-frontend)

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -3233,5 +3233,13 @@ frontends = [
         selector       = "et-syr-cookie-preferences"
       }
     ]
-  }
+  },
+  {
+    name              = "pcs-frontend"
+    mode              = "Prevention"
+    custom_domain     = "pcs.perftest.platform.hmcts.net"
+    dns_zone_name     = "perftest.platform.hmcts.net"
+    backend_domain    = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
+    global_exclusions = []
+  },
 ]


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### environments/ithc/ithc.tfvars
- Added a new block of configuration for \"pcs-frontend\" with mode \"Prevention\", custom domain, DNS zone name, and backend domain.

