### PR TITLE
HDPI-48 - Adding front door configuration for PCS frontend in ITHC

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -3233,5 +3233,13 @@ frontends = [
         selector       = "et-syr-cookie-preferences"
       }
     ]
-  }
+  },
+  {
+    name              = "pcs-frontend"
+    mode              = "Prevention"
+    custom_domain     = "pcs.ithc.platform.hmcts.net"
+    dns_zone_name     = "ithc.platform.hmcts.net"
+    backend_domain    = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
+    global_exclusions = []
+  },
 ]


### PR DESCRIPTION
### Jira link

[HDPI-48](https://tools.hmcts.net/jira/browse/HDPI-48)

### Change description

Adding front door configuration for PCS frontend in ITHC

### Testing done

None - configuration change.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/ithc/ithc.tfvars
- Added a new entry for \"pcs-frontend\" with mode \"Prevention\", custom domain \"pcs.ithc.platform.hmcts.net\", DNS zone name \"ithc.platform.hmcts.net\", backend domain \"firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com\", and an empty global exclusions array.