### PR TITLE
Allow dtSa cookie to accept value on TT Demo

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3553,9 +3553,9 @@ frontends = [
         selector       = "dtSa"
       },
       {
-        match_variable = "RequestCookies"
-        operator       = "StartsWith"
-        selector       = "dtSa=true|C|"
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "CookieValue:dtSa"
       },
       {
         match_variable = "RequestBodyPostArgNames"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3556,7 +3556,7 @@ frontends = [
         match_variable = "RequestCookies"
         operator       = "StartsWith"
         selector       = "dtSa=true|C|"
-      }
+      },
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3551,7 +3551,7 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
-      }
+      },
       {
         match_variable = "RequestCookies"
         operator       = "StartsWith"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3551,7 +3551,12 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
-      },
+      }
+      {
+        match_variable = "RequestCookies"
+        operator       = "StartsWith"
+        selector       = "dtSa=true|C|"
+      }
       {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added a new match_variable configuration for RequestBodyPostArgNames with operator \"Equals\" and selector \"CookieValue:dtSa\".