### PR TITLE
DTSPO-22820 adding condition for pubsub subnet

### DIFF
--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -39,6 +39,7 @@ module "pubsubappgateway" {
   enable_waf                         = true
   app_gateway_name                   = "cft-fe-${format("%02d", count.index)}-${var.env}-agw-pubsub"
   pip_name                           = "cft-pubsub-fe-appgw-${var.env}-pip"
+  pubsub_subnet                      = true
   waf_policy_name                    = "pubsub-waf-policy"
   waf_managed_rules                  = var.pubsub_waf_managed_rules
 }


### PR DESCRIPTION
### Jira link

[DTSPO-22820](https://tools.hmcts.net/jira/browse/DTSPO-22820)

### Change description

adding a condition so the pubsub app gateway uses the correct subnet




## 🤖AEP PR SUMMARY🤖


### components/pubsubappgateway/main.tf
- Added support for a new feature `pubsub_subnet` to enable the usage of a subnet for Pub/Sub.