### PR TITLE
DTSPO-22820 Adding pubsub settings to other envs

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -56,11 +56,11 @@ parameters:
       storage_account_rg: 'core-infra-sbox-rg'
       storage_account_name: 'cftappssbox'
       dependsOn: 'Precheck'
-      pipeline_tests: false
+      pipeline_tests: false'
 
-    - deployment: 'sbox_pubsubfrontendappgateway'
+    - deployment: 'sbox_pubsubappgateway'
       environment: 'sbox'
-      component: 'pubsubfrontendappgateway'
+      component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-sbox'
       storage_account_rg: 'core-infra-sbox-rg'
       storage_account_name: 'cftappssbox'
@@ -138,9 +138,9 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'ithc_pubsubfrontendappgateway'
+    - deployment: 'ithc_pubsubappgateway'
       environment: 'ithc'
-      component: 'pubsubfrontendappgateway'
+      component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
@@ -249,9 +249,9 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'test_pubsubfrontendappgateway'
+    - deployment: 'test_pubsubappgateway'
       environment: 'test'
-      component: 'pubsubfrontendappgateway'
+      component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
@@ -339,9 +339,9 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'stg_pubsubfrontendappgateway'
+    - deployment: 'stg_pubsubappgateway'
       environment: 'stg'
-      component: 'pubsubfrontendappgateway'
+      component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
@@ -383,9 +383,9 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: false
 
-    - deployment: 'prod_pubsubfrontendappgateway'
+    - deployment: 'prod_pubsubappgateway'
       environment: 'prod'
-      component: 'pubsubfrontendappgateway'
+      component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -56,7 +56,7 @@ parameters:
       storage_account_rg: 'core-infra-sbox-rg'
       storage_account_name: 'cftappssbox'
       dependsOn: 'Precheck'
-      pipeline_tests: false'
+      pipeline_tests: false
 
     - deployment: 'sbox_pubsubappgateway'
       environment: 'sbox'

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -58,15 +58,6 @@ parameters:
       dependsOn: 'Precheck'
       pipeline_tests: false
 
-    - deployment: 'sbox_pubsubappgateway'
-      environment: 'sbox'
-      component: 'pubsubappgateway'
-      service_connection: 'dcd-cftapps-sbox'
-      storage_account_rg: 'core-infra-sbox-rg'
-      storage_account_name: 'cftappssbox'
-      dependsOn: 'Precheck'
-      pipeline_tests: false
-
     - deployment: 'sbox_global'
       environment: 'sbox'
       component: 'global'
@@ -144,7 +135,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_pubsubappgateway'
+      dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
     - deployment: 'ithc_backendappgateway'
@@ -204,7 +195,7 @@ parameters:
       service_connection: 'dcd-cftapps-demo'
       storage_account_rg: 'core-infra-demo-rg'
       storage_account_name: 'cftappsdemo'
-      dependsOn: 'sbox_pubsubappgateway'
+      dependsOn: 'sbox_frontendappgateway'
 
     - deployment: 'demo_backendappgateway'
       environment: 'demo'
@@ -249,13 +240,13 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'test_pubsubappgateway'
+    - deployment: 'perftest_pubsubappgateway'
       environment: 'test'
       component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_pubsubappgateway'
+      dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
     - deployment: 'test_backendappgateway'
@@ -339,13 +330,13 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'stg_pubsubappgateway'
+    - deployment: 'aat_pubsubappgateway'
       environment: 'stg'
       component: 'pubsubappgateway'
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
-      dependsOn: 'sbox_pubsubappgateway'
+      dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
     - deployment: 'stg_backendappgateway'
@@ -389,7 +380,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_pubsubappgateway'
+      dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: false
 
     - deployment: 'prod_backendappgateway'

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -144,7 +144,7 @@ parameters:
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_pubsubappgateway'
       pipeline_tests: true
 
     - deployment: 'ithc_backendappgateway'
@@ -204,7 +204,7 @@ parameters:
       service_connection: 'dcd-cftapps-demo'
       storage_account_rg: 'core-infra-demo-rg'
       storage_account_name: 'cftappsdemo'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_pubsubappgateway'
 
     - deployment: 'demo_backendappgateway'
       environment: 'demo'
@@ -255,7 +255,7 @@ parameters:
       service_connection: 'dcd-cftapps-test'
       storage_account_rg: 'core-infra-test-rg'
       storage_account_name: 'cftappstest'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_pubsubappgateway'
       pipeline_tests: true
 
     - deployment: 'test_backendappgateway'
@@ -345,7 +345,7 @@ parameters:
       service_connection: 'dcd-cftapps-stg'
       storage_account_rg: 'core-infra-stg-rg'
       storage_account_name: 'cftappsstg'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_pubsubappgateway'
       pipeline_tests: true
 
     - deployment: 'stg_backendappgateway'
@@ -389,7 +389,7 @@ parameters:
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'
-      dependsOn: 'sbox_frontendappgateway'
+      dependsOn: 'sbox_pubsubappgateway'
       pipeline_tests: false
 
     - deployment: 'prod_backendappgateway'

--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -58,6 +58,15 @@ parameters:
       dependsOn: 'Precheck'
       pipeline_tests: false
 
+    - deployment: 'sbox_pubsubfrontendappgateway'
+      environment: 'sbox'
+      component: 'pubsubfrontendappgateway'
+      service_connection: 'dcd-cftapps-sbox'
+      storage_account_rg: 'core-infra-sbox-rg'
+      storage_account_name: 'cftappssbox'
+      dependsOn: 'Precheck'
+      pipeline_tests: false
+
     - deployment: 'sbox_global'
       environment: 'sbox'
       component: 'global'
@@ -123,6 +132,15 @@ parameters:
     - deployment: 'ithc_frontendappgateway'
       environment: 'ithc'
       component: 'frontendappgateway'
+      service_connection: 'dcd-cftapps-ithc'
+      storage_account_rg: 'core-infra-ithc-rg'
+      storage_account_name: 'cftappsithc'
+      dependsOn: 'sbox_frontendappgateway'
+      pipeline_tests: true
+
+    - deployment: 'ithc_pubsubfrontendappgateway'
+      environment: 'ithc'
+      component: 'pubsubfrontendappgateway'
       service_connection: 'dcd-cftapps-ithc'
       storage_account_rg: 'core-infra-ithc-rg'
       storage_account_name: 'cftappsithc'
@@ -231,6 +249,15 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
+    - deployment: 'test_pubsubfrontendappgateway'
+      environment: 'test'
+      component: 'pubsubfrontendappgateway'
+      service_connection: 'dcd-cftapps-test'
+      storage_account_rg: 'core-infra-test-rg'
+      storage_account_name: 'cftappstest'
+      dependsOn: 'sbox_frontendappgateway'
+      pipeline_tests: true
+
     - deployment: 'test_backendappgateway'
       environment: 'test'
       component: 'backendappgateway'
@@ -312,6 +339,15 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
+    - deployment: 'stg_pubsubfrontendappgateway'
+      environment: 'stg'
+      component: 'pubsubfrontendappgateway'
+      service_connection: 'dcd-cftapps-stg'
+      storage_account_rg: 'core-infra-stg-rg'
+      storage_account_name: 'cftappsstg'
+      dependsOn: 'sbox_frontendappgateway'
+      pipeline_tests: true
+
     - deployment: 'stg_backendappgateway'
       environment: 'stg'
       component: 'backendappgateway'
@@ -341,6 +377,15 @@ parameters:
     - deployment: 'prod_frontendappgateway'
       environment: 'prod'
       component: 'frontendappgateway'
+      service_connection: 'dcd-cftapps-prod'
+      storage_account_rg: 'core-infra-prod-rg'
+      storage_account_name: 'cftappsprod'
+      dependsOn: 'sbox_frontendappgateway'
+      pipeline_tests: false
+
+    - deployment: 'prod_pubsubfrontendappgateway'
+      environment: 'prod'
+      component: 'pubsubfrontendappgateway'
       service_connection: 'dcd-cftapps-prod'
       storage_account_rg: 'core-infra-prod-rg'
       storage_account_name: 'cftappsprod'

--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -36,7 +36,7 @@ module "pubsubappgateway" {
   max_capacity                       = var.frontend_agw_max_capacity
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
   enable_waf                         = true
-  app_gateway_name                   = "cft-fe-${format("%02d", )}-${var.env}-agw-pubsub"
+  app_gateway_name                   = "cft-fe-${var.env}-agw-pubsub"
   pip_name                           = "cft-pubsub-fe-appgw-${var.env}-pip"
   pubsub_subnet                      = true
   waf_policy_name                    = "pubsub-waf-policy"

--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -17,7 +17,6 @@ data "azurerm_subscription" "current" {}
 module "pubsubappgateway" {
   source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=master"
 
-  count = var.env == "demo" ? 1 : 0
 
   env                                = var.env
   subscription                       = var.subscription

--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -36,7 +36,7 @@ module "pubsubappgateway" {
   max_capacity                       = var.frontend_agw_max_capacity
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
   enable_waf                         = true
-  app_gateway_name                   = "cft-fe-${format("%02d", count.index)}-${var.env}-agw-pubsub"
+  app_gateway_name                   = "cft-fe-${format("%02d", )}-${var.env}-agw-pubsub"
   pip_name                           = "cft-pubsub-fe-appgw-${var.env}-pip"
   pubsub_subnet                      = true
   waf_policy_name                    = "pubsub-waf-policy"

--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -37,9 +37,9 @@ module "pubsubappgateway" {
   max_capacity                       = var.frontend_agw_max_capacity
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
   enable_waf                         = true
-  app_gateway_name                   = "cft-fe-${format("%02d", count.index)}-${var.env}-agw-pubsub"
-  pip_name                           = "cft-pubsub-fe-appgw-${var.env}-pip"
+  app_gateway_name                   = "em-fe-${format("%02d", count.index)}-${var.env}-agw-pubsub"
+  pip_name                           = "em-pubsub-fe-appgw-${var.env}-pip"
   pubsub_subnet                      = true
-  waf_policy_name                    = "pubsub-waf-policy"
+  waf_policy_name                    = "em-pubsub-waf-policy"
   waf_managed_rules                  = var.pubsub_waf_managed_rules
 }

--- a/components/pubsubappgateway/main.tf
+++ b/components/pubsubappgateway/main.tf
@@ -17,6 +17,7 @@ data "azurerm_subscription" "current" {}
 module "pubsubappgateway" {
   source = "git::https://github.com/hmcts/terraform-module-applicationgateway.git?ref=master"
 
+  count = var.env == "sbox" ? 0 : 1
 
   env                                = var.env
   subscription                       = var.subscription
@@ -36,7 +37,7 @@ module "pubsubappgateway" {
   max_capacity                       = var.frontend_agw_max_capacity
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
   enable_waf                         = true
-  app_gateway_name                   = "cft-fe-${var.env}-agw-pubsub"
+  app_gateway_name                   = "cft-fe-${format("%02d", count.index)}-${var.env}-agw-pubsub"
   pip_name                           = "cft-pubsub-fe-appgw-${var.env}-pip"
   pubsub_subnet                      = true
   waf_policy_name                    = "pubsub-waf-policy"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -20,8 +20,10 @@ shutter_apps = [
   "TODO"
 ]
 
-frontend_agw_private_ip_address = "10.11.225.113"
-cft_apps_cluster_ips            = ["10.11.207.250", "10.11.223.250"]
+frontend_agw_private_ip_address        = "10.11.225.113"
+cft_apps_cluster_ips                   = ["10.11.207.250", "10.11.223.250"]
+pubsub_endpoint                        = ["10.11.228.50"]
+pubsub_frontend_agw_private_ip_address = "10.11.226.8"
 
 frontends = [
   {
@@ -3247,4 +3249,39 @@ frontends = [
     backend_domain    = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
     global_exclusions = []
   },
+]
+
+pubsub_frontends = [
+  {
+    product        = "em"
+    name           = "em-icp-webpubsub"
+    mode           = "Detection"
+    custom_domain  = "em-icp-webpubsub.ithc.platform.hmcts.net"
+    dns_zone_name  = "ithc.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
+  },
+]
+
+pubsub_waf_managed_rules = [
+  {
+    type    = "OWASP"
+    version = "3.2"
+    rule_group_override = [
+      {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+        rule = [
+          {
+            id      = "920300"
+            enabled = true
+            action  = "Log"
+          },
+          {
+            id      = "920440"
+            enabled = true
+            action  = "Block"
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -8,12 +8,14 @@ sku_tier               = "Standard"
 sku_size               = "Standard"
 
 
-backend_agw_private_ip_address = ["10.90.96.20", "10.90.96.21"]
-backend_agw_min_capacity       = 10
-backend_agw_max_capacity       = 15
-data_subscription              = "8999dec3-0104-4a27-94ee-6588559729d1"
-privatedns_subscription        = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-oms_env                        = "prod"
+backend_agw_private_ip_address         = ["10.90.96.20", "10.90.96.21"]
+backend_agw_min_capacity               = 10
+backend_agw_max_capacity               = 15
+data_subscription                      = "8999dec3-0104-4a27-94ee-6588559729d1"
+privatedns_subscription                = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+oms_env                                = "prod"
+pubsub_endpoint                        = ["10.50.100.50"]
+pubsub_frontend_agw_private_ip_address = "10.50.98.8"
 
 cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"
@@ -4240,6 +4242,41 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "et-syr-cookie-preferences"
+      }
+    ]
+  }
+]
+
+pubsub_frontends = [
+  {
+    product        = "em"
+    name           = "em-icp-webpubsub"
+    mode           = "Detection"
+    custom_domain  = "em-icp-webpubsub.prod.platform.hmcts.net"
+    dns_zone_name  = "prod.platform.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]
+  },
+]
+
+pubsub_waf_managed_rules = [
+  {
+    type    = "OWASP"
+    version = "3.2"
+    rule_group_override = [
+      {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+        rule = [
+          {
+            id      = "920300"
+            enabled = true
+            action  = "Log"
+          },
+          {
+            id      = "920440"
+            enabled = true
+            action  = "Block"
+          }
+        ]
       }
     ]
   }

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -14,8 +14,8 @@ backend_agw_max_capacity               = 15
 data_subscription                      = "8999dec3-0104-4a27-94ee-6588559729d1"
 privatedns_subscription                = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
 oms_env                                = "prod"
-pubsub_endpoint                        = ["10.50.100.50"]
-pubsub_frontend_agw_private_ip_address = "10.50.98.8"
+pubsub_endpoint                        = ["10.90.100.50"]
+pubsub_frontend_agw_private_ip_address = "10.90.98.8"
 
 cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-prod-rg"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -1,17 +1,15 @@
-project                                = "hmcts"
-location                               = "uksouth"
-env                                    = "sbox"
-subscription                           = "sbox"
-sku_tier                               = "Standard"
-sku_size                               = "Standard"
-hub_app_gw_private_ip_address          = ["10.10.200.212"]
-backend_agw_private_ip_address         = ["10.2.13.112"]
-data_subscription                      = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
-key_vault_subscription                 = "b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
-privatedns_subscription                = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
-oms_env                                = "sandbox"
-pubsub_endpoint                        = ["10.2.15.50"]
-pubsub_frontend_agw_private_ip_address = "10.2.12.132"
+project                        = "hmcts"
+location                       = "uksouth"
+env                            = "sbox"
+subscription                   = "sbox"
+sku_tier                       = "Standard"
+sku_size                       = "Standard"
+hub_app_gw_private_ip_address  = ["10.10.200.212"]
+backend_agw_private_ip_address = ["10.2.13.112"]
+data_subscription              = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+key_vault_subscription         = "b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
+privatedns_subscription        = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+oms_env                        = "sandbox"
 
 #FrontDoor access policy
 add_access_policy = true
@@ -735,40 +733,5 @@ apim_appgw_exclusions = [
     match_variable = "RequestArgNames"
     operator       = "Equals"
     selector       = "iss"
-  }
-]
-
-pubsub_frontends = [
-  {
-    product        = "em"
-    name           = "em-icp-webpubsub"
-    mode           = "Detection"
-    custom_domain  = "em-icp-webpubsub.sandbox.platform.hmcts.net"
-    dns_zone_name  = "sandbox.platform.hmcts.net"
-    backend_domain = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
-  },
-]
-
-pubsub_waf_managed_rules = [
-  {
-    type    = "OWASP"
-    version = "3.2"
-    rule_group_override = [
-      {
-        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
-        rule = [
-          {
-            id      = "920300"
-            enabled = true
-            action  = "Log"
-          },
-          {
-            id      = "920440"
-            enabled = true
-            action  = "Block"
-          }
-        ]
-      }
-    ]
   }
 ]

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -1,15 +1,17 @@
-project                        = "hmcts"
-location                       = "uksouth"
-env                            = "sbox"
-subscription                   = "sbox"
-sku_tier                       = "Standard"
-sku_size                       = "Standard"
-hub_app_gw_private_ip_address  = ["10.10.200.212"]
-backend_agw_private_ip_address = ["10.2.13.112"]
-data_subscription              = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
-key_vault_subscription         = "b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
-privatedns_subscription        = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
-oms_env                        = "sandbox"
+project                                = "hmcts"
+location                               = "uksouth"
+env                                    = "sbox"
+subscription                           = "sbox"
+sku_tier                               = "Standard"
+sku_size                               = "Standard"
+hub_app_gw_private_ip_address          = ["10.10.200.212"]
+backend_agw_private_ip_address         = ["10.2.13.112"]
+data_subscription                      = "bf308a5c-0624-4334-8ff8-8dca9fd43783"
+key_vault_subscription                 = "b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb"
+privatedns_subscription                = "1497c3d7-ab6d-4bb7-8a10-b51d03189ee3"
+oms_env                                = "sandbox"
+pubsub_endpoint                        = ["10.2.15.50"]
+pubsub_frontend_agw_private_ip_address = "10.2.12.132"
 
 #FrontDoor access policy
 add_access_policy = true
@@ -733,5 +735,40 @@ apim_appgw_exclusions = [
     match_variable = "RequestArgNames"
     operator       = "Equals"
     selector       = "iss"
+  }
+]
+
+pubsub_frontends = [
+  {
+    product        = "em"
+    name           = "em-icp-webpubsub"
+    mode           = "Detection"
+    custom_domain  = "em-icp-webpubsub.sandbox.platform.hmcts.net"
+    dns_zone_name  = "sandbox.platform.hmcts.net"
+    backend_domain = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
+  },
+]
+
+pubsub_waf_managed_rules = [
+  {
+    type    = "OWASP"
+    version = "3.2"
+    rule_group_override = [
+      {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+        rule = [
+          {
+            id      = "920300"
+            enabled = true
+            action  = "Log"
+          },
+          {
+            id      = "920440"
+            enabled = true
+            action  = "Block"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -4,15 +4,17 @@ env                    = "aat"
 subscription           = "stg"
 certificate_name_check = false
 
-backend_agw_private_ip_address = ["10.10.161.100", "10.10.161.101"]
-data_subscription              = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-privatedns_subscription        = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-oms_env                        = "nonprod"
-autoShutdown                   = true
-hub                            = "prod"
-key_vault_subscription         = "96c274ce-846d-4e48-89a7-d528432298a7"
-hub_app_gw_private_ip_address  = ["10.11.8.215"]
-apim_appgw_backend_pool_fqdns  = ["firewall-prod-int-palo-cftapimgmtstg.uksouth.cloudapp.azure.com"]
+backend_agw_private_ip_address         = ["10.10.161.100", "10.10.161.101"]
+data_subscription                      = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+privatedns_subscription                = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+oms_env                                = "nonprod"
+autoShutdown                           = true
+hub                                    = "prod"
+key_vault_subscription                 = "96c274ce-846d-4e48-89a7-d528432298a7"
+hub_app_gw_private_ip_address          = ["10.11.8.215"]
+apim_appgw_backend_pool_fqdns          = ["firewall-prod-int-palo-cftapimgmtstg.uksouth.cloudapp.azure.com"]
+pubsub_endpoint                        = ["10.10.164.50"]
+pubsub_frontend_agw_private_ip_address = "10.10.169.8"
 
 shutter_storage = "TODO"
 cdn_sku         = "TODO"
@@ -3987,4 +3989,39 @@ frontends = [
     backend_domain    = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
     global_exclusions = []
   },
+]
+
+pubsub_frontends = [
+  {
+    product        = "em"
+    name           = "em-icp-webpubsub"
+    mode           = "Detection"
+    custom_domain  = "em-icp-webpubsub.aat.platform.hmcts.net"
+    dns_zone_name  = "aat.platform.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
+  },
+]
+
+pubsub_waf_managed_rules = [
+  {
+    type    = "OWASP"
+    version = "3.2"
+    rule_group_override = [
+      {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+        rule = [
+          {
+            id      = "920300"
+            enabled = true
+            action  = "Log"
+          },
+          {
+            id      = "920440"
+            enabled = true
+            action  = "Block"
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -4,14 +4,16 @@ env                    = "perftest"
 subscription           = "test"
 certificate_name_check = false
 
-backend_agw_private_ip_address = ["10.48.96.111", "10.48.96.114"]
-data_subscription              = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-privatedns_subscription        = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
-oms_env                        = "nonprod"
-autoShutdown                   = true
-shutter_storage                = "TODO"
-cdn_sku                        = "TODO"
-shutter_rg                     = "TODO"
+backend_agw_private_ip_address         = ["10.48.96.111", "10.48.96.114"]
+data_subscription                      = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+privatedns_subscription                = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+oms_env                                = "nonprod"
+autoShutdown                           = true
+shutter_storage                        = "TODO"
+cdn_sku                                = "TODO"
+shutter_rg                             = "TODO"
+pubsub_endpoint                        = ["10.48.96.50"]
+pubsub_frontend_agw_private_ip_address = "10.48.100.8"
 
 # Applications associated with default storage account shutter static website.
 # Teams that need a default shutter page, should add their app frontend names to the list below.
@@ -2827,4 +2829,39 @@ frontends = [
     backend_domain    = ["firewall-nonprodi-palo-cft-perftest.uksouth.cloudapp.azure.com"]
     global_exclusions = []
   },
+]
+
+pubsub_frontends = [
+  {
+    product        = "em"
+    name           = "em-icp-webpubsub"
+    mode           = "Detection"
+    custom_domain  = "em-icp-webpubsub.perftest.platform.hmcts.net"
+    dns_zone_name  = "perftest.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-cft-perftest.uksouth.cloudapp.azure.com"]
+  },
+]
+
+pubsub_waf_managed_rules = [
+  {
+    type    = "OWASP"
+    version = "3.2"
+    rule_group_override = [
+      {
+        rule_group_name = "REQUEST-920-PROTOCOL-ENFORCEMENT"
+        rule = [
+          {
+            id      = "920300"
+            enabled = true
+            action  = "Log"
+          },
+          {
+            id      = "920440"
+            enabled = true
+            action  = "Block"
+          }
+        ]
+      }
+    ]
+  }
 ]


### PR DESCRIPTION
### Jira link

[DTSPO-22820](https://tools.hmcts.net/jira/browse/DTSPO-22820)

### Change description

Creating pubsub app gateways for other envs 



















## 🤖AEP PR SUMMARY🤖


### azure_pipeline.yaml
- Added deployment configurations for different environments with pubsubappgateway and backendappgateway components.
- Updated the pipeline_tests parameter for each deployment, setting it to true for all environments except prod where it is set to false.

### components/pubsubappgateway/main.tf
- Updated the count condition to include the pubsubappgateway component only for environments other than \"sbox\".
- Changed the names and labels for app_gateway_name, pip_name, and waf_policy_name based on the environment.

### environments/ithc/ithc.tfvars
- Added pubsub_endpoint and pubsub_frontends configurations for the \"ithc\" environment.

### environments/prod/prod.tfvars
- Added pubsub_endpoint and pubsub_frontends configurations for the \"prod\" environment.

### environments/stg/stg.tfvars
- Added pubsub_endpoint and pubsub_frontends configurations for the \"stg\" environment.

### environments/test/test.tfvars
- Added pubsub_endpoint and pubsub_frontends configurations for the \"test\" environment.