### PR TITLE
CUI disable csrf check on perf test

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3825,6 +3825,11 @@ frontends = [
         operator       = "Equals"
         selector       = "rf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
     ]
   },
   {

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -3109,6 +3109,11 @@ frontends = [
         operator       = "Equals"
         selector       = "rf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
     ]
   },
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -4278,6 +4278,11 @@ frontends = [
         operator       = "Equals"
         selector       = "rf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
     ]
   },
   {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2796,6 +2796,11 @@ frontends = [
         operator       = "Equals"
         selector       = "rf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
     ]
   },
   {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CUIRA-384

### Change description
Disable _csrf check

### Testing done
Creating PR to perftest to check, and if it works raise on all other envs




## 🤖AEP PR SUMMARY🤖


- The changes include adding a new configuration to the terraform variables file for demo, ithc, prod, and test environments. 
- In each file, a new configuration block is added for frontends with \"match_variable\" set to \"RequestBodyPostArgNames\", \"operator\" set to \"Equals\", and \"selector\" set to \"_csrf\".