### PR TITLE
Exclude csrf from aat env

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -3699,6 +3699,11 @@ frontends = [
         operator       = "Equals"
         selector       = "rf"
       },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "_csrf"
+      },
     ]
   },
   {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/CUIRA-384

### Change description
Exclude _csrf value check in aat




## 🤖AEP PR SUMMARY🤖


### environments/stg/stg.tfvars
- Added a new match condition for the \"RequestBodyPostArgNames\" with operator \"Equals\" and selector \"_csrf\" within the \"frontends\" block.