### PR TITLE
Revert "Platops/dtspo 23355 private law waf2.1ruleset"

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2313,8 +2313,8 @@ frontends = [
         match_conditions = [
           {
             match_variable     = "RequestHeader"
-            operator           = "Equal"
             selector           = "Content-Type"
+            operator           = "Equal"
             negation_condition = false
             match_values       = ["application/json"]
           },
@@ -2329,6 +2329,7 @@ frontends = [
     ]
     disabled_rules = {
       SQLI = [
+        "942260",
         "942340"
       ]
       LFI = [


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2391

## 🤖AEP PR SUMMARY🤖


### environments/ithc/ithc.tfvars
- Changed the `operator` value from \"Equal\" to \"Equal\" with `negation_condition` set to false for the `match_conditions` in the frontends.
- Added security rules with IDs \"942260\" and \"942340\" to the SQLI category under `disabled_rules`.