### PR TITLE
Revert "Platops/dtspo 23355 private law waf2.1ruleset"

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2304,29 +2304,6 @@ frontends = [
     mode             = "Prevention"
     backend_domain   = ["firewall-nonprodi-palo-cftithc.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-ithc-platform-hmcts-net"
-    custom_rules = [
-      {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestHeader"
-            selector           = "Content-Type"
-            operator           = "Equal"
-            negation_condition = false
-            match_values       = ["application/json"]
-          },
-          {
-            match_variable     = "RequestBody"
-            operator           = "Contains"
-            negation_condition = false
-            match_values       = ["<script>"]
-          }
-        ]
-      }
-    ]
     disabled_rules = {
       SQLI = [
         "942260",
@@ -2337,9 +2314,6 @@ frontends = [
       ]
       RCE = [
         "932115"
-      ]
-      RFI = [
-        "931130"
       ]
     }
     global_exclusions = [
@@ -2449,6 +2423,7 @@ frontends = [
       SQLI = [
         "942200",
         "942450",
+        "942260",
         "942440"
       ]
       LFI = [
@@ -2456,9 +2431,6 @@ frontends = [
       ]
       RCE = [
         "932115"
-      ]
-      RFI = [
-        "931130"
       ]
     },
     global_exclusions = [


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2388

## 🤖AEP PR SUMMARY🤖


- Modified `ithc.tfvars` in the `environments/ithc` directory.
- Removed custom rules for blocking scripts in JSON.
- Removed RFI rules.
- Updated SQLI rules and added \"942260\" to the list.
- No longer contains RFI rules.