### PR TITLE
Platops/23355

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2306,25 +2306,33 @@ frontends = [
     certificate_name = "wildcard-ithc-platform-hmcts-net"
     custom_rules = [
       {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
+        name      = "BlockScriptInJSON"
+        priority  = 1
+        rule_type = "MatchRule"
         match_conditions = [
           {
-            match_variable     = "RequestHeader"
-            selector           = "Content-Type"
+            match_variables = [
+              {
+                variable_name = "RequestHeader"
+                selector      = "Content-Type"
+              }
+            ]
             operator           = "Equal"
             negation_condition = false
             match_values       = ["application/json"]
           },
           {
-            match_variable     = "RequestBody"
+            match_variables = [
+              {
+                variable_name = "RequestBody"
+              }
+            ]
             operator           = "Contains"
             negation_condition = false
             match_values       = ["<script>"]
           }
         ]
+        action = "Block"
       }
     ]
     disabled_rules = {

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2306,35 +2306,34 @@ frontends = [
     certificate_name = "wildcard-ithc-platform-hmcts-net"
     custom_rules = [
       {
-        name      = "BlockScriptInJSON"
-        priority  = 1
-        rule_type = "MatchRule"
+        name     = "BlockScriptInJSON"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
         match_conditions = [
           {
-            match_variables = [
-              {
-                variable_name = "RequestHeader"
-                selector      = "Content-Type"
-              }
-            ]
+            match_variable     = "RequestHeader"
             operator           = "Equal"
             negation_condition = false
             match_values       = ["application/json"]
-          },
+          }
+        ]
+      },
+      {
+        name     = "BlockScriptInJSON2"
+        priority = 2
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
           {
-            match_variables = [
-              {
-                variable_name = "RequestBody"
-              }
-            ]
+            match_variable     = "RequestBody"
             operator           = "Contains"
             negation_condition = false
             match_values       = ["<script>"]
           }
         ]
-        action = "Block"
-      }
-    ]
+      },
+    ],
     disabled_rules = {
       SQLI = [
         "942260",


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/secure/RapidBoard.jspa?rapidView=1598&view=detail&selectedIssue=DTSPO-23355&quickFilter=21506#:~:text=DTS%20Platform%20Operations-,DTSPO%2D23355,-Close%20detail%20(%20T

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description
Correcting syntax
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- File: ithc.tfvars
- Added a new match rule \"BlockScriptInJSON2\" with priority 2, type \"MatchRule\", and action \"Block\" to match request body for \"<script>\" and block the request if it contains a script in JSON format.