### PR TITLE
DTSPO-23915 removing ithc pubsub from pipeline

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -129,15 +129,6 @@ parameters:
       dependsOn: 'sbox_frontendappgateway'
       pipeline_tests: true
 
-    - deployment: 'ithc_pubsubappgateway'
-      environment: 'ithc'
-      component: 'pubsubappgateway'
-      service_connection: 'dcd-cftapps-ithc'
-      storage_account_rg: 'core-infra-ithc-rg'
-      storage_account_name: 'cftappsithc'
-      dependsOn: 'sbox_frontendappgateway'
-      pipeline_tests: true
-
     - deployment: 'ithc_backendappgateway'
       environment: 'ithc'
       component: 'backendappgateway'


### PR DESCRIPTION
### Jira link

[DTSPO-23915](https://tools.hmcts.net/jira/browse/DTSPO-23915)

### Change description

removing ithc pubsub from pipeline so that we can test changes without the pipeline overriding them



## 🤖AEP PR SUMMARY🤖


- **azure_pipeline.yaml**
  - Removed the `ithc_pubsubappgateway` deployment block and its associated parameters and dependencies.
  - Removed the `ithc_backendappgateway` deployment block's `service_connection`, `storage_account_rg`, and `storage_account_name` parameters.