### PR TITLE
Adding WAF excepotion for deceased name

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3740,6 +3740,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "online_search[reference]"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "application[deceased_name]"
       }
     ]
   },

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -4005,6 +4005,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "_hwf-publicapp_session"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "application[deceased_name]"
       }
     ]
     custom_rules = [

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -4004,6 +4004,11 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "online_search[reference]"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "application[deceased_name]"
       }
     ]
   },


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/RST-7155

## 🤖AEP PR SUMMARY🤖


### demo.tfvars
- Added rules for `RequestBodyPostArgNames` with `selector` values for `online_search[reference]` and `application[deceased_name]` to the `frontends` list at line 3740.

### prod.tfvars
- Added rules for `RequestCookieNames` with `selector` value of `_hwf-publicapp_session` and `RequestBodyPostArgNames` with `selector` value of `application[deceased_name]` to the `frontends` list at line 4005.

### stg.tfvars
- Added rules for `RequestBodyPostArgNames` with `selector` values for `online_search[reference]` and `application[deceased_name]` to the `frontends` list at line 4004.