### PR TITLE
Revert "FPET-1263 / DTSPO-23355 WAF changes to prevention mode && ITHC issue fix VUL-6219 "

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1844,54 +1844,8 @@ frontends = [
     name           = "privatelaw"
     custom_domain  = "privatelaw.demo.platform.hmcts.net"
     dns_zone_name  = "demo.platform.hmcts.net"
-    mode           = "Prevention"
+    mode           = "Detection"
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
-    custom_rules = [
-      {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestHeader"
-            selector           = "content-type"
-            operator           = "Equal"
-            negation_condition = false
-            match_values       = ["application/json"]
-          }
-        ]
-      },
-      {
-        name     = "BlockScriptInJSON2"
-        priority = 2
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestBody"
-            operator           = "Contains"
-            negation_condition = false
-            match_values       = ["<script>"]
-          }
-        ]
-      },
-    ],
-    disabled_rules = {
-      SQLI = [
-        "942340",
-        "942440"
-      ]
-      LFI = [
-        "930130"
-      ]
-      RCE = [
-        "932115"
-      ]
-      RFI = [
-        "931130"
-      ]
-    }
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -3278,57 +3278,11 @@ frontends = [
   {
     product          = "prl"
     name             = "private-law"
-    mode             = "Prevention"
+    mode             = "Detection"
     custom_domain    = "www.apply-to-court-about-child-arrangements-c100.service.gov.uk"
     dns_zone_name    = "apply-to-court-about-child-arrangements-c100.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-cftprod.uksouth.cloudapp.azure.com"]
     certificate_name = "apply-to-court-about-child-arrangements-c100-service-gov-uk"
-    custom_rules = [
-      {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestHeader"
-            selector           = "content-type"
-            operator           = "Equal"
-            negation_condition = false
-            match_values       = ["application/json"]
-          }
-        ]
-      },
-      {
-        name     = "BlockScriptInJSON2"
-        priority = 2
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestBody"
-            operator           = "Contains"
-            negation_condition = false
-            match_values       = ["<script>"]
-          }
-        ]
-      },
-    ],
-    disabled_rules = {
-      SQLI = [
-        "942340",
-        "942440"
-      ]
-      LFI = [
-        "930130"
-      ]
-      RCE = [
-        "932115"
-      ]
-      RFI = [
-        "931130"
-      ]
-    }
     global_exclusions = [
       {
         match_variable = "RequestCookieNames"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -3519,54 +3519,8 @@ frontends = [
     name           = "privatelaw"
     custom_domain  = "privatelaw.aat.platform.hmcts.net"
     dns_zone_name  = "aat.platform.hmcts.net"
-    mode           = "Prevention"
+    mode           = "Detection"
     backend_domain = ["firewall-prod-int-palo-cftaat.uksouth.cloudapp.azure.com"]
-    custom_rules = [
-      {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestHeader"
-            selector           = "content-type"
-            operator           = "Equal"
-            negation_condition = false
-            match_values       = ["application/json"]
-          }
-        ]
-      },
-      {
-        name     = "BlockScriptInJSON2"
-        priority = 2
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestBody"
-            operator           = "Contains"
-            negation_condition = false
-            match_values       = ["<script>"]
-          }
-        ]
-      },
-    ],
-    disabled_rules = {
-      SQLI = [
-        "942340",
-        "942440"
-      ]
-      LFI = [
-        "930130"
-      ]
-      RCE = [
-        "932115"
-      ]
-      RFI = [
-        "931130"
-      ]
-    }
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2444,54 +2444,8 @@ frontends = [
     name           = "privatelaw"
     custom_domain  = "privatelaw.perftest.platform.hmcts.net"
     dns_zone_name  = "perftest.platform.hmcts.net"
-    mode           = "Prevention"
+    mode           = "Detection"
     backend_domain = ["firewall-nonprodi-palo-cft-perftest.uksouth.cloudapp.azure.com"]
-    custom_rules = [
-      {
-        name     = "BlockScriptInJSON"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestHeader"
-            selector           = "content-type"
-            operator           = "Equal"
-            negation_condition = false
-            match_values       = ["application/json"]
-          }
-        ]
-      },
-      {
-        name     = "BlockScriptInJSON2"
-        priority = 2
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RequestBody"
-            operator           = "Contains"
-            negation_condition = false
-            match_values       = ["<script>"]
-          }
-        ]
-      },
-    ],
-    disabled_rules = {
-      SQLI = [
-        "942340",
-        "942440"
-      ]
-      LFI = [
-        "930130"
-      ]
-      RCE = [
-        "932115"
-      ]
-      RFI = [
-        "931130"
-      ]
-    }
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2413

## 🤖AEP PR SUMMARY🤖


- environments/demo/demo.tfvars```
  - Changed the \"mode\" from \"Prevention\" to \"Detection\" for the \"privatelaw\" frontend.
  
- ```environments/prod/prod.tfvars```
  - Changed the \"mode\" from \"Prevention\" to \"Detection\" for the \"private-law\" frontend.
  
- ```environments/stg/stg.tfvars```
  - Changed the \"mode\" from \"Prevention\" to \"Detection\" for the \"privatelaw\" frontend.
  
- ```environments/test/test.tfvars```
  - Changed the \"mode\" from \"Prevention\" to \"Detection\" for the \"privatelaw\" frontend.