### PR TITLE
Removing mode key from pubsub frontend map as is not use

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3872,7 +3872,6 @@ pubsub_frontends = [
   {
     product       = "em"
     name          = "em-icp-webpubsub"
-    mode          = "Detection"
     custom_domain = "em-icp-webpubsub.demo.platform.hmcts.net"
     dns_zone_name = "demo.platform.hmcts.net"
     backend_fqdn  = ["firewall-nonprodi-palo-empubsubdemo.uksouth.cloudapp.azure.com"]

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -3340,7 +3340,6 @@ pubsub_frontends = [
   {
     product       = "em"
     name          = "em-icp-webpubsub"
-    mode          = "Detection"
     custom_domain = "em-icp-webpubsub.ithc.platform.hmcts.net"
     dns_zone_name = "ithc.platform.hmcts.net"
     backend_fqdn  = ["firewall-nonprodi-palo-empubsubithc.uksouth.cloudapp.azure.com"]

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -4311,7 +4311,6 @@ pubsub_frontends = [
   {
     product       = "em"
     name          = "em-icp-webpubsub"
-    mode          = "Detection"
     custom_domain = "em-icp-webpubsub.prod.platform.hmcts.net"
     dns_zone_name = "prod.platform.hmcts.net"
     backend_fqdn  = ["firewall-prod-int-palo-empubsubprod.uksouth.cloudapp.azure.com"]

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -4040,7 +4040,6 @@ pubsub_frontends = [
   {
     product       = "em"
     name          = "em-icp-webpubsub"
-    mode          = "Detection"
     custom_domain = "em-icp-webpubsub.aat.platform.hmcts.net"
     dns_zone_name = "aat.platform.hmcts.net"
     backend_fqdn  = ["firewall-prod-int-palo-empubsubaat.uksouth.cloudapp.azure.com"]

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -2839,7 +2839,6 @@ pubsub_frontends = [
   {
     product       = "em"
     name          = "em-icp-webpubsub"
-    mode          = "Detection"
     custom_domain = "em-icp-webpubsub.perftest.platform.hmcts.net"
     dns_zone_name = "perftest.platform.hmcts.net"
     backend_fqdn  = ["firewall-nonprodi-palo-empubsubperftest.uksouth.cloudapp.azure.com"]


### PR DESCRIPTION
### Change description

Removing waf mode key from from pubsub map as this not use

setting is set from here:
https://github.com/hmcts/terraform-module-applicationgateway/blob/master/variables.tf#L86