### PR TITLE
Update sbox.tfvars with Dan nodejs frontend

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -748,7 +748,7 @@ frontends = [
     dns_zone_name    = "sandbox.platform.hmcts.net"
     shutter_app      = false
     backend_domain   = ["firewall-sbox-int-palo-labs-gunnertwin-nodejs.uksouth.cloudapp.azure.com"]
-    certificate_name  = "wildcard-sandbox-platform-hmcts-net"
+    certificate_name = "wildcard-sandbox-platform-hmcts-net"
     disabled_rules   = {}
   }
 ]

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -740,8 +740,17 @@ frontends = [
     appgw_cookie_based_affinity    = "Enabled"
     cache_enabled                  = "false"
     certificate_name_check_enabled = false
+  },
+  {
+    product          = "labs-gunnertwin-nodejs"
+    name             = "labs-gunnertwin-nodejs"
+    custom_domain    = "labs-gunnertwin-nodejs.sandbox.platform.hmcts.net"
+    dns_zone_name    = "sandbox.platform.hmcts.net"
+    shutter_app      = false
+    backend_domain   = ["firewall-sbox-int-palo-labs-gunnertwin-nodejs.uksouth.cloudapp.azure.com"]
+    certificate_name  = "wildcard-sandbox-platform-hmcts-net"
+    disabled_rules   = {}
   }
-
 ]
 
 apim_appgw_exclusions = [

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -701,10 +701,10 @@ frontends = [
   {
     product          = "plumclassic"
     name             = "plumclassic"
-    custom_domain    = "frontdoor.sandbox.platform.hmcts.net"
-    dns_zone_name    = "frontdoor.sandbox.platform.hmcts.net"
+    custom_domain    = "sandbox.platform.hmcts.net"
+    dns_zone_name    = "sandbox.platform.hmcts.net"
     backend_domain   = ["firewall-sbox-int-palo-sbox.uksouth.cloudapp.azure.com"]
-    certificate_name = "frontdoor-sandbox-platform-hmcts-net"
+    certificate_name = "wildcard-sandbox-platform-hmcts-net"
     disabled_rules   = {}
     shutter_app      = true
     ssl_mode         = "AzureKeyVault"


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPO-25106](https://tools.hmcts.net/jira/browse/DTSPO-25106)

### Change description
Golden path nodejs app for Dan Alves
Also had to update plum frontend due to this [commit](https://github.com/hmcts/azure-public-dns/commit/404bd1b850c44c5a03c39905537414cb6c55e657)

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- In `environments/sbox/sbox.tfvars`, a new configuration block for the `labs-gunnertwin-nodejs` product has been added, with custom domain, DNS zone name, backend domain, and other settings.