### PR TITLE
Revert "DTSPO-24310: Temporarily removing cft-sbox-01-aks from load balancer"

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -24,7 +24,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-sbox-rg"
 
 frontend_agw_private_ip_address = "10.2.13.114"
-cft_apps_cluster_ips            = ["10.2.9.250"]
+cft_apps_cluster_ips            = ["10.2.9.250", "10.2.11.250"]
 
 apim_appgw_backend_pool_fqdns = ["firewall-sbox-int-palo-cftapimgmt.uksouth.cloudapp.azure.com"]
 


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2450

Adding cft-sbox-01-aks back into load balancer

## 🤖AEP PR SUMMARY🤖


### environments/sbox/sbox.tfvars
- Added a new IP address \"10.2.11.250\" to the `cft_apps_cluster_ips` array.