### PR TITLE
Temporarily increase definition store request timeout

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -112,7 +112,7 @@ gateways:
         component: data-store-api
       - product: ccd
         component: definition-store-api
-          request_timeout: 180
+        request_timeout: 180
       - product: ccd
         component: user-profile-api
       - product: ccd

--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -112,6 +112,7 @@ gateways:
         component: data-store-api
       - product: ccd
         component: definition-store-api
+          request_timeout: 180
       - product: ccd
         component: user-profile-api
       - product: ccd


### PR DESCRIPTION
### Jira link
See [CCD-6206](https://tools.hmcts.net/jira/browse/CCD-6206)

### Change description
Temporarily increase definition store request timeout , to allow importing Civil definition files.

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change





## 🤖AEP PR SUMMARY🤖


### environments/demo/backend_lb_config.yaml
- Added a `request_timeout` of 180 for the `definition-store-api` component.
- Changed the structure to include the `request_timeout` for the `definition-store-api` component.