### PR TITLE
Revert "abhivan golden-path test"

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -740,16 +740,6 @@ frontends = [
     appgw_cookie_based_affinity    = "Enabled"
     cache_enabled                  = "false"
     certificate_name_check_enabled = false
-  },
-  {
-    product          = "labs-abhivan-nodejs"
-    name             = "labs-abhivan-nodejs"
-    custom_domain    = "labs-abhivan-nodejs.sandbox.platform.hmcts.net"
-    dns_zone_name    = "sandbox.platform.hmcts.net"
-    shutter_app      = false
-    backend_domain   = ["firewall-sbox-int-palo-labs-abhivan-nodejs.uksouth.cloudapp.azure.com"]
-    certificate_name = "wildcard-sandbox-platform-hmcts-net"
-    disabled_rules   = {}
   }
 ]
 


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2455

Cleanup golden-path changes

## 🤖AEP PR SUMMARY🤖


### environments/sbox/sbox.tfvars
- Removed a block of configuration for \"labs-abhivan-nodejs\".
- The `labs-abhivan-nodejs` product and its associated configuration were removed from the `sbox.tfvars` file.