### PR TITLE
ADOP-2484: Add 'iss' exclusion for login /receiver call

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2489,6 +2489,11 @@ frontends = [
       {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
+        selector       = "iss"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
         selector       = "rf"
       },
       {


### PR DESCRIPTION
### Jira link

<!-- 
[ADOP-2484](https://tools.hmcts.net/jira/browse/ADOP-2484)

### Change description
 - Add query param value iss for login via IDAM hitting the /receiver callback (like many other services)

### Testing done
 - Replicated existing configurations
 - This is the testing in ITHC!

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/ithc/ithc.tfvars
- Added a new global exclusion for \"QueryStringArgNames\" with the selector \"iss\" using the operator \"Equals\".