### PR TITLE
removing sbox-01 from app gateway

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -24,7 +24,7 @@ cdn_sku    = "Standard_Verizon"
 shutter_rg = "shutter-app-sbox-rg"
 
 frontend_agw_private_ip_address = "10.2.13.114"
-cft_apps_cluster_ips            = ["10.2.9.250", "10.2.11.250"]
+cft_apps_cluster_ips            = ["10.2.9.250"]
 
 apim_appgw_backend_pool_fqdns = ["firewall-sbox-int-palo-cftapimgmt.uksouth.cloudapp.azure.com"]
 


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25672

### Change description
Removing sbox-01 from app gateway for upgrade from AKS version 1.30 to 1.32

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### environments/sbox/sbox.tfvars
- Removed the second IP address from the `cft_apps_cluster_ips` list, leaving only one IP address.