### PR TITLE
Remove cft-demo-01 from app gw for upgrade

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1,6 +1,6 @@
 env                    = "demo"
 subscription           = "demo"
-cft_apps_cluster_ips   = ["10.50.79.221", "10.50.95.221"]
+cft_apps_cluster_ips   = ["10.50.79.221"]
 certificate_name_check = false
 autoShutdown           = true
 pubsubappgw_ssl_policy = {


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25674

### Change description
Remove cft-demo-01 from app gw for upgrade

## 🤖AEP PR SUMMARY🤖


- File: `environments/demo/demo.tfvars`
- Removed IP address `10.50.95.221` from the `cft_apps_cluster_ips` list
- Set `certificate_name_check` to `false`
- Enabled `autoShutdown`
- Updated `pubsubappgw_ssl_policy`