### PR TITLE
Revert "Remove demo00 from gateway for Terraform update first"

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -1,6 +1,6 @@
 env                    = "demo"
 subscription           = "demo"
-cft_apps_cluster_ips   = ["10.50.95.221"]
+cft_apps_cluster_ips   = ["10.50.79.221", "10.50.95.221"]
 certificate_name_check = false
 autoShutdown           = true
 pubsubappgw_ssl_policy = {


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2480

## 🤖AEP PR SUMMARY🤖


- environments/demo/demo.tfvars
  - The `cft_apps_cluster_ips` array has been updated to include both \"10.50.79.221\" and \"10.50.95.221\" IP addresses.