### PR TITLE
DTSPO-25686: Removing perftest-01 from the app gateway

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -28,7 +28,7 @@ shutter_apps = [
 
 cft_apps_ag_ip_address          = "10.48.96.123"
 frontend_agw_private_ip_address = "10.48.96.113"
-cft_apps_cluster_ips            = ["10.48.95.250"]
+cft_apps_cluster_ips            = ["10.48.79.250"]
 
 hub                           = "nonprod"
 key_vault_subscription        = "8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25686

### Change description

- Removing perftest-01 from the app gateway for upgrades.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/test/test.tfvars
- Removed one IP address from the `cft_apps_cluster_ips` list, leaving only one IP address.