### PR TITLE
Revert "DTSPO-25686: Removing perftest-01 from the app gateway"

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -28,7 +28,7 @@ shutter_apps = [
 
 cft_apps_ag_ip_address          = "10.48.96.123"
 frontend_agw_private_ip_address = "10.48.96.113"
-cft_apps_cluster_ips            = ["10.48.79.250"]
+cft_apps_cluster_ips            = ["10.48.79.250", "10.48.95.250"]
 
 hub                           = "nonprod"
 key_vault_subscription        = "8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2488

## 🤖AEP PR SUMMARY🤖


### environments/test/test.tfvars
- Added a new IP address \"10.48.95.250\" to the \"cft_apps_cluster_ips\" list.