### PR TITLE
Revert "DTSPO-25686: Removing aat-00 from app gateway for upgrade"

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -32,7 +32,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.10.161.102"
-cft_apps_cluster_ips            = ["10.10.159.250"]
+cft_apps_cluster_ips            = ["10.10.143.250", "10.10.159.250"]
 
 publisher_email = "DTSPlatformOps@HMCTS.NET"
 


### PR DESCRIPTION
Reverts hmcts/azure-platform-terraform#2493

## 🤖AEP PR SUMMARY🤖


- Changed `stg.tfvars`
- Updated `cft_apps_cluster_ips` from `[\"10.10.159.250\"]` to `[\"10.10.143.250\", \"10.10.159.250\"]`