### PR TITLE
ADOP-2484: Update rules - allow details of document uploads through firewall

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -2502,6 +2502,11 @@ frontends = [
     certificate_name = "wildcard-ithc-platform-hmcts-net"
     global_exclusions = [
       {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "laUploadedFiles"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [ADOP-2484](https://tools.hmcts.net/jira/browse/ADOP-2484)

### Change description
 - Allow the successful payload of the document uploads to be allowed through. It is currently being blocked as it contains the filename to be linked to the case.

### Testing done
 - Currently blocked in the ITHC environment, this is a test to enable the functionality in prevention mode.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/ithc/ithc.tfvars
- Added a new global exclusion for `RequestBodyPostArgNames` in the `frontends` configuration. 🔄