### PR TITLE
Fixed exclusions for et1 demo and switched to detection

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3823,7 +3823,7 @@ frontends = [
     backend_domain   = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
     global_exclusions = [
-            {
+      {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "cookie_setting"


### PR DESCRIPTION




## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2526

## 🤖AEP PR SUMMARY🤖


- In `demo.tfvars`, the `mode` field for \"et-pet-et1\" has been changed from \"Prevention\" to \"Detection\".