### PR TITLE
Adding non-prod environments to the upgraded TLS policy

### DIFF
--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" && var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" || var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || var.env == "test" || var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env !== "prod" && var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -44,7 +44,7 @@ module "app-gw" {
   waf_mode                                     = var.waf_mode
   exclusions                                   = var.apim_appgw_exclusions
   public_ip_enable_multiple_availability_zones = true
-  enable_multiple_availability_zones           = var.env == "sbox" ? false : true
+  enable_multiple_availability_zones           = var.env == "sbox" || "perftest" ? false : true
   min_capacity                                 = var.apim_appgw_min_capacity
   max_capacity                                 = var.apim_appgw_max_capacity
 

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" || var.env != "stg" ? local.current_ssl_policy : var.ssl_policy
+  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -44,12 +44,12 @@ module "app-gw" {
   waf_mode                                     = var.waf_mode
   exclusions                                   = var.apim_appgw_exclusions
   public_ip_enable_multiple_availability_zones = true
-  enable_multiple_availability_zones           = var.env == "sbox" || "perftest" ? false : true
+  enable_multiple_availability_zones           = var.env == "sbox" || var.env == "perftest" ? false : true
   min_capacity                                 = var.apim_appgw_min_capacity
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || "perftest" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || var.env == "perftest" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || var.env == "perftest" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || var.env == "test" || var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || "perftest" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" || var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" || var.env != "stg" ? local.current_ssl_policy : var.ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env !== "prod" && var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" && var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -49,7 +49,7 @@ module "app-gw" {
   max_capacity                                 = var.apim_appgw_max_capacity
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 
   trusted_client_certificate_data = merge(
     {

--- a/components/apim-appgw/main.tf
+++ b/components/apim-appgw/main.tf
@@ -44,7 +44,7 @@ module "app-gw" {
   waf_mode                                     = var.waf_mode
   exclusions                                   = var.apim_appgw_exclusions
   public_ip_enable_multiple_availability_zones = true
-  enable_multiple_availability_zones           = var.env == "sbox" || var.env == "perftest" ? false : true
+  enable_multiple_availability_zones           = var.env == "sbox" ? false : true
   min_capacity                                 = var.apim_appgw_min_capacity
   max_capacity                                 = var.apim_appgw_max_capacity
 

--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -41,5 +41,5 @@ module "backendappgateway" {
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -41,5 +41,5 @@ module "backendappgateway" {
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/local.tf
+++ b/components/frontendappgateway/local.tf
@@ -2,6 +2,7 @@ locals {
   vnet_rg                  = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "prod" || var.env == "demo" ? "cft-${var.env}-network-rg" : "aks-infra-${var.env}-rg"
   vnet_name                = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "prod" || var.env == "demo" ? "cft-${var.env}-vnet" : "core-${var.env}-vnet"
   hub_env                  = (var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "perftest") ? "nonprod" : (var.env == "aat") ? "prod" : var.env
+  env = (var.env == "aat") ? "stg" : "${(var.env == "perftest") ? "test" : "${var.env}"}"
   key_vault_name           = "acmedcdcftapps${var.subscription}"
   key_vault_resource_group = "cft-platform-${var.subscription}-rg"
 

--- a/components/frontendappgateway/local.tf
+++ b/components/frontendappgateway/local.tf
@@ -2,7 +2,7 @@ locals {
   vnet_rg                  = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "prod" || var.env == "demo" ? "cft-${var.env}-network-rg" : "aks-infra-${var.env}-rg"
   vnet_name                = var.env == "sbox" || var.env == "perftest" || var.env == "aat" || var.env == "ithc" || var.env == "prod" || var.env == "demo" ? "cft-${var.env}-vnet" : "core-${var.env}-vnet"
   hub_env                  = (var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "perftest") ? "nonprod" : (var.env == "aat") ? "prod" : var.env
-  env = (var.env == "aat") ? "stg" : "${(var.env == "perftest") ? "test" : "${var.env}"}"
+  env                      = (var.env == "aat") ? "stg" : "${(var.env == "perftest") ? "test" : "${var.env}"}"
   key_vault_name           = "acmedcdcftapps${var.subscription}"
   key_vault_resource_group = "cft-platform-${var.subscription}-rg"
 

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || "perftest" ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" || var.env != "stg" ? local.current_ssl_policy : var.ssl_policy
+  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || "perftest" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || var.env == "perftest" ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || var.env == "perftest" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env == "sbox" || var.env == "test" || var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = (local.env != "stg" && local.env != "prod") ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = (var.env != "stg" && var.env != "prod") ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env == "sbox" || var.env == "test" || var.env == "demo" || var.env == "dev" || var.env == "ithc" || var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env !== "prod" && var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" && var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" || var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env != "prod" || var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" || var.env != "stg" ? local.current_ssl_policy : var.ssl_policy
 }

--- a/components/frontendappgateway/main.tf
+++ b/components/frontendappgateway/main.tf
@@ -45,5 +45,5 @@ module "frontendappgateway" {
   ssl_certificate_name               = var.ssl_certificate
 
   # Control the rollout of the TLS 1.0/1.1 deprecation, the ternary should be removed once the rollout is complete
-  ssl_policy = var.env !== "prod" && var.env == "stg" ? var.ssl_policy : local.current_ssl_policy
+  ssl_policy = var.env != "prod" && var.env != "stg" ? var.ssl_policy : local.current_ssl_policy
 }


### PR DESCRIPTION
### Jira link

DTSPO-26836

### Change description

Disabling TLS on perftest to keep in line with Microsoft ending support

### Testing done

PoC confirmed on sbox: https://github.com/hmcts/azure-platform-terraform/pull/2546/files


































## 🤖AEP PR SUMMARY🤖


- `components/apim-appgw/main.tf`:
  - Updated the logic for setting `ssl_policy` based on environment, excluding \"stg\" and \"prod\" environments from the condition.

- `components/backendappgateway/main.tf`:
  - Updated the logic for setting `ssl_policy` based on environment, excluding \"stg\" and \"prod\" environments from the condition.

- `components/frontendappgateway/local.tf`:
  - Updated the `env` local variable to set \"stg\" environment as \"aat\", and dynamically update the \"test\" environment based on the `var.env` value.

- `components/frontendappgateway/main.tf`:
  - Updated the logic for setting `ssl_policy` based on environment, excluding \"stg\" and \"prod\" environments from the condition.