### PR TITLE
labs-hurricanepilot-nodejs front door config

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -755,6 +755,16 @@ frontends = [
     appgw_cookie_based_affinity    = "Enabled"
     cache_enabled                  = "false"
     certificate_name_check_enabled = false
+  },
+  {
+    product          = "labs-hurricanepilot-nodejs"
+    name             = "labs-hurricanepilot-nodejs"
+    custom_domain    = "labs-hurricanepilot-nodejs.sandbox.platform.hmcts.net"
+    dns_zone_name    = "sandbox.platform.hmcts.net"
+    shutter_app      = false
+    backend_domain   = ["firewall-sbox-int-palo-labs-hurricanepilot-nodejs.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-sandbox-platform-hmcts-net"
+    disabled_rules   = {}
   }
 ]
 


### PR DESCRIPTION
### Change description

Adding front door config for `labs-hurricanepilot-nodejs` as per instructions in the nodejs golden path


## 🤖AEP PR SUMMARY🤖


- **sbox.tfvars**
  - Added a new configuration for \"labs-hurricanepilot-nodejs\" backend including custom domain, DNS zone name, firewall domain, and certificate name.