### PR TITLE
DTSPO-27727 Fix pre-commit failures due to not fetching full commit h…

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-27727

### Change description

Pre-commit is failing due to task stefanzweifel/git-auto-commit-action@v6 is unable to see full commit history before push.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Updated `.github/workflows/pre-commit.yml`
- Added a `fetch-depth` parameter with a value of 0 to the `Checkout` action step