### PR TITLE
FACT-2484 enable ssl fact

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -214,6 +214,7 @@ gateways:
         component: api
       - product: fact
         component: data-api
+        ssl_enabled: true
 
       # NFDIV
       - product: nfdiv

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -210,6 +210,7 @@ gateways:
         component: api
       - product: fact
         component: data-api
+        ssl_enabled: true
 
     # NFDIV
       - product: nfdiv

--- a/environments/prod/backend_lb_config.yaml
+++ b/environments/prod/backend_lb_config.yaml
@@ -235,6 +235,7 @@ gateways:
         component: api
       - product: fact
         component: data-api
+        ssl_enabled: true
 
  # Docmosis
       - product: dg

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -228,6 +228,7 @@ gateways:
         component: api
       - product: fact
         component: data-api
+        ssl_enabled: true
 
       # NFDIV
       - product: nfdiv

--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -224,6 +224,7 @@ gateways:
         component: api
       - product: fact
         component: data-api
+        ssl_enabled: true
 
     # NFDIV
       - product: nfdiv


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/FACT-2484

### Change description

Enabled ssl for new fact api

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `backend_lb_config.yaml`:
  - Added `ssl_enabled: true` for the `data-api` component in the demo, ithc, prod, stg, and test environments.