### PR TITLE
Add update functionality to comments

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -96,7 +96,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments?per_page=100)
           comment_id=$(echo "$comments_json" | jq -r '[.[] | select(.user.login=="github-actions[bot]") | .id][0] // ""')
           echo "comment_id=$comment_id" >> $GITHUB_ENV
           echo "Resolved comment id: ${comment_id:-<none>}"


### PR DESCRIPTION
### Change description

Enable functionality for existing comments to be updated rather than creating multiple comments.
Will only work if the bot comments once per run.

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change







## 🤖AEP PR SUMMARY🤖


- The file `.github/workflows/pr-reviewer.yml` has been updated to include a new step that gets the github-actions bot comment ID if it exists and creates or updates a PR review comment accordingly. This involves using the `actions/github-script@v6` action to achieve this functionality.
- The update includes the addition of a new job and the modification of an existing job to incorporate the functionality for getting and creating or updating a PR review comment using the GitHub API.