### PR TITLE
DTSPO-27918 Remove cft-aat-01-aks from AppGW for upgrade v1.33

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -32,7 +32,7 @@ shutter_apps = [
 ]
 
 frontend_agw_private_ip_address = "10.10.161.102"
-cft_apps_cluster_ips            = ["10.10.143.250", "10.10.159.250"]
+cft_apps_cluster_ips            = ["10.10.143.250"]
 
 publisher_email = "DTSPlatformOps@HMCTS.NET"
 


### PR DESCRIPTION
### Jira link

DTSPO-27918

### Change description

Remove cft-aat-01-aks from AppGW for upgrade v1.33


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2630

## 🤖AEP PR SUMMARY🤖


### environments/stg/stg.tfvars
- Removed one IP address from `cft_apps_cluster_ips` list.
- Updated `publisher_email` to \"DTSPlatformOps@HMCTS.NET\".