### PR TITLE
DTSPO-27911 Remove cft-perftest-01 from AppGW for upgrade v1.33

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -28,7 +28,7 @@ shutter_apps = [
 
 cft_apps_ag_ip_address          = "10.48.96.123"
 frontend_agw_private_ip_address = "10.48.96.113"
-cft_apps_cluster_ips            = ["10.48.79.250", "10.48.95.250"]
+cft_apps_cluster_ips            = ["10.48.79.250"]
 
 hub                           = "nonprod"
 key_vault_subscription        = "8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c"


### PR DESCRIPTION
Jira link
[DTSPO-27911](https://tools.hmcts.net/jira/browse/DTSPO-27911)

Change description
Remove cft-perftest-01-aks from AppGW for upgrade v1.33

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2636

## 🤖AEP PR SUMMARY🤖


### test.tfvars
- Removed one IP address from the `cft_apps_cluster_ips` list.
- Updated the `hub` and `key_vault_subscription` values.