### PR TITLE
Sbox: Caching behaviour should be disabled for idamwebpublic's custom rules

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -72,7 +72,7 @@ frontends = [
                   # This key must exist in local.origin_group_ids
                   cdn_frontdoor_origin_group_key = "hmcts-access"
                   forwarding_protocol            = "HttpOnly"
-                  cache_behavior                 = "HonorOrigin"
+                  cache_behavior                 = "Disabled"
                 }
               ]
             }
@@ -97,7 +97,7 @@ frontends = [
                 {
                   cdn_frontdoor_origin_group_key = "hmcts-access"
                   forwarding_protocol            = "HttpOnly"
-                  cache_behavior                 = "HonorOrigin"
+                  cache_behavior                 = "Disabled"
                 }
               ]
             }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10016

### Change description
This PR is a continuation of https://github.com/hmcts/azure-platform-terraform/pull/2659 and is created to validate and test the updates proposed in https://github.com/hmcts/terraform-module-frontdoor/pull/65.

The `terraform apply` showed an issue with the caching_behaviour setting for the new rules - this should be `Disabled`.
### Testing done



### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2665

## 🤖AEP PR SUMMARY🤖



- **environments/sbox/sbox.tfvars**  
  🔧 Changed `cache_behavior` value from `\"HonorOrigin\"` to `\"Disabled\"` in two frontend configurations.