### PR TITLE
Update the Terraform Front Door module source ref from a feature branch to master

### DIFF
--- a/components/global/main.tf
+++ b/components/global/main.tf
@@ -9,7 +9,7 @@ moved {
   to   = module.premium_front_door
 }
 module "premium_front_door" {
-  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=feature/frontdoor-custom-rule-sets"
+  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=master"
 
   common_tags                = module.ctags.common_tags
   env                        = var.env


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10016


### Change description
This reverts the change done in https://github.com/hmcts/azure-platform-terraform/pull/2659 in order to test a feature branch in terraform-module-frontdoor. The feature branch is now merged, therefore reverting back to master.

### Testing done
Reviewed TF plans.

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2667

## 🤖AEP PR SUMMARY🤖



- **components/global/main.tf** 🔄  
  Updated the `premium_front_door` module source reference from the `feature/frontdoor-custom-rule-sets` branch to the `master` branch in the Terraform module Git URL.