### PR TITLE
SIDM-10124: Test the implementation plan for HMCTS Access Go Live on AAT and Demo

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3442,6 +3442,101 @@ frontends = [
     mode           = "Prevention"
     dns_zone_name  = "demo.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-cftdemoappgateway.uksouth.cloudapp.azure.com"]
+    rule_sets = [
+      {
+        name = "hmcts-access-overrides"
+        rules = [
+          {
+            name              = "StopIfClientIdExistsButDoesNotMatch"
+            order             = 1
+            behavior_on_match = "Stop"
+
+            conditions = {
+              query_string_conditions = [
+                {
+                  operator         = "Contains"
+                  negate_condition = false
+                  match_values = [
+                    "client_id="
+                  ]
+                  transforms = ["Lowercase"]
+                },
+                {
+                  operator         = "Contains"
+                  negate_condition = true
+                  match_values = [
+                    "client_id=idam_user_dashboard"
+                  ]
+                  transforms = ["Lowercase"]
+                }
+              ]
+            }
+
+            actions = {
+              route_configuration_override_actions = [
+                {
+                  cdn_frontdoor_origin_group_key = "idam-web-public"
+                  forwarding_protocol            = "HttpOnly"
+                  cache_behavior                 = "Disabled"
+                }
+              ]
+            }
+          },
+          {
+            name  = "UseHmctsAccessIfClientIdMatches"
+            order = 2
+
+            conditions = {
+              query_string_conditions = [
+                {
+                  operator         = "Contains"
+                  negate_condition = false
+                  match_values = [
+                    "client_id=idam_user_dashboard"
+                  ]
+                  transforms = ["Lowercase"]
+                }
+              ]
+            }
+
+            actions = {
+              route_configuration_override_actions = [
+                {
+                  cdn_frontdoor_origin_group_key = "hmcts-access"
+                  forwarding_protocol            = "HttpOnly"
+                  cache_behavior                 = "Disabled"
+                }
+              ]
+            }
+          },
+          {
+            name  = "UseHmctsAccessIfIdamUiCookie"
+            order = 3
+
+            conditions = {
+              cookies_conditions = [
+                {
+                  cookie_name      = "Idam.UI"
+                  operator         = "Equal"
+                  match_values     = ["hmcts-access"]
+                  negate_condition = false
+                }
+              ]
+            }
+
+            actions = {
+              route_configuration_override_actions = [
+                {
+                  cdn_frontdoor_origin_group_key = "hmcts-access"
+                  forwarding_protocol            = "HttpOnly"
+                  cache_behavior                 = "Disabled"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10124

### Change description
Deploy Front Door custom rules for idam-web-public in AAT and Demo.

### Testing done

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2694

## 🤖AEP PR SUMMARY🤖



### File: environments/demo/demo.tfvars 🌐
- Added `rule_sets` configuration under `frontends` to implement custom routing and behavior rules:
  - Rule \"StopIfClientIdExistsButDoesNotMatch\": Stops requests if `client_id` query string exists but does not equal \"idam_user_dashboard\".
  - Rule \"UseHmctsAccessIfClientIdMatches\": Routes requests to \"hmcts-access\" if `client_id` equals \"idam_user_dashboard\".
  - Rule \"UseHmctsAccessIfIdamUiCookie\": Routes requests to \"hmcts-access\" if `Idam.UI` cookie equals \"hmcts-access\".
- Each rule sets routing behavior such as forwarding protocol (HttpOnly) and disables cache.

### File: environments/stg/stg.tfvars 🌐
- Mirrored additions of `rule_sets` configuration in the `frontends` block similar to demo environment:
  - Introduced the same three rules (\"StopIfClientIdExistsButDoesNotMatch,\" \"UseHmctsAccessIfClientIdMatches,\" \"UseHmctsAccessIfIdamUiCookie\") with identical logic and actions.
- Ensured feature parity in staging environment for conditional routing and access override based on query parameters and cookies.