### PR TITLE
Add hmcts-access required exclusions to idam-web-public's WAF exclusion list

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -3844,6 +3844,21 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "code_verifier"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "connect.sid"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "id_token_hint"
       }
     ]
   },

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -477,6 +477,21 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "code_verifier"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "connect.sid"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "id_token_hint"
       }
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -2937,6 +2937,21 @@ frontends = [
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "code_verifier"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "Idam.Request"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "connect.sid"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "id_token_hint"
       }
     ]
   },


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10124

### Change description
Include hmcts-access cookies to idam-web-public's waf exclusion list as it will be analysing them when dual routing.

### Testing done
Reviews TF plans.

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2698

## 🤖AEP PR SUMMARY🤖



- **environments/demo/demo.tfvars** 🚀
  - Added new frontend match rules to include checks for cookies (\"Idam.Request\", \"connect.sid\") and query string argument (\"id_token_hint\").

- **environments/ithc/ithc.tfvars** 🚀
  - Added the same frontend match rules as demo environment for cookie names (\"Idam.Request\", \"connect.sid\") and query string argument (\"id_token_hint\").

- **environments/stg/stg.tfvars** 🚀
  - Included identical frontend match rules for \"Idam.Request\" and \"connect.sid\" cookies and the \"id_token_hint\" query string argument as in demo and ithc environments.