### PR TITLE
Use redirect ruleset for courts transcribe

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -158,11 +158,11 @@ frontends = [
               ]
             }
             actions = {
-              route_configuration_override_actions = [
+              url_redirect_actions = [
                 {
-                  cdn_frontdoor_origin_group_key = "courtstranscribe-backend"
-                  forwarding_protocol            = "HttpsOnly"
-                  cache_behavior                 = "Disabled"
+                  redirect_type        = "Moved"
+                  redirect_protocol    = "Https"
+                  destination_hostname = "hmcts-transcribe-backend-dev.azurewebsites.net"
                 }
               ]
             }
@@ -186,40 +186,11 @@ frontends = [
               ]
             }
             actions = {
-              route_configuration_override_actions = [
+              url_redirect_actions = [
                 {
-                  cdn_frontdoor_origin_group_key = "courtstranscribe-storage"
-                  forwarding_protocol            = "HttpOnly"
-                  cache_behavior                 = "Disabled"
-                }
-              ]
-            }
-          },
-          {
-            name              = "HMCTSCourtsTranscribeFrontend"
-            order             = 3
-            behavior_on_match = "Stop"
-            conditions = {
-              url_path_conditions = [
-                {
-                  operator         = "BeginsWith"
-                  negate_condition = true
-                  match_values = [
-                    "api/",
-                    "application-data/",
-                    "transcription-processing/",
-                    "storage/",
-                  ]
-                  transforms = ["Lowercase"]
-                }
-              ]
-            }
-            actions = {
-              route_configuration_override_actions = [
-                {
-                  cdn_frontdoor_origin_group_key = "courtstranscribe"
-                  forwarding_protocol            = "HttpOnly"
-                  cache_behavior                 = "Disabled"
+                  redirect_type        = "Moved"
+                  redirect_protocol    = "Https"
+                  destination_hostname = "hmctstranscribedevsa.privatelink.blob.core.windows.net"
                 }
               ]
             }

--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -198,39 +198,5 @@ frontends = [
         ]
       }
     ]
-  },
-  {
-    name          = "courtstranscribe-backend"
-    custom_domain = "courtstranscribe.dev.apps.hmcts.net"
-    dns_zone_name = "dev.apps.hmcts.net"
-    backend_domain = [
-      "hmcts-transcribe-backend-dev.azurewebsites.net"
-    ]
-    mode                           = "Detection"
-    appgw_cookie_based_affinity    = "Enabled"
-    cache_enabled                  = "false"
-    forwarding_protocol            = "HttpsOnly"
-    certificate_name_check_enabled = true
-    private_link = {
-      target_id   = "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/courtstranscribe-dev-rg/providers/Microsoft.Web/sites/hmcts-transcribe-backend-dev"
-      location    = "uksouth"
-      target_type = "sites"
-    }
-  },
-  {
-    name           = "courtstranscribe-storage"
-    custom_domain  = "courtstranscribe.dev.apps.hmcts.net"
-    dns_zone_name  = "dev.apps.hmcts.net"
-    backend_domain = ["hmctstranscribedevsa.blob.core.windows.net"]
-    host_header    = "hmctstranscribedevsa.blob.core.windows.net"
-
-    private_link = {
-      target_id   = "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/courtstranscribe-dev-rg/providers/Microsoft.Storage/storageAccounts/hmctstranscribedevsa"
-      location    = "uksouth"
-      target_type = "blob"
-    }
-
-    forwarding_protocol = "HttpsOnly"
-    cache_enabled       = "false"
   }
 ]


### PR DESCRIPTION
### Change description

Add redirect custom rule set to send traffic on `/storage` to storage account private endpoint and `/api` to backend app service

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2858

## 🤖AEP PR SUMMARY🤖



### environments/dev/dev.tfvars
- 🔄 Replaced `route_configuration_override_actions` with `url_redirect_actions` for routing actions.
- 🚦 Updated redirects for backend and storage origins to use:
  - `redirect_type = \"Moved\"`
  - `redirect_protocol = \"Https\"`
  - Specific `destination_hostname` for backend and storage.
- 🗑️ Removed a frontend configuration block with complex path-based behavior and routing.
- ❌ Removed backend and storage origin configurations including private link settings and custom domains.