### PR TITLE
Remove private link from dev environment in courts transcribe

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -114,11 +114,6 @@ frontends = [
     cache_enabled                  = "false"
     forwarding_protocol            = "HttpsOnly"
     certificate_name_check_enabled = true
-    private_link = {
-      target_id   = "/subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/courtstranscribe-dev-rg/providers/Microsoft.Web/sites/hmcts-transcribe-frontend-dev"
-      location    = "uksouth"
-      target_type = "sites"
-    }
     disabled_rules = {
       SQLI = [
         "942430",


### PR DESCRIPTION
### Change description

Remove private link in dev environment for courts transcribe as this shouldn't be required

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/azure-platform-terraform/2879

## 🤖AEP PR SUMMARY🤖



- **environments/dev/dev.tfvars**:  
  ➖ Removed the `private_link` configuration block within the `frontends` section, which previously specified a target ID, location, and target type for a private link connection.  
  This change effectively disables the private link setup for the dev environment frontend.